### PR TITLE
[native-image] Provide an option for `Entity` scan to use `BeanIntrospector`

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-projectVersion=1.1.1.BUILD-SNAPSHOT
+projectVersion=1.2.0.BUILD-SNAPSHOT
 reactivePgClientVersion=0.11.3
 jasyncClientVersion=0.9.51
 kafkaVersion=2.1.0
@@ -11,7 +11,7 @@ commonsDbcpVersion=2.6.0
 micrometerVersion=1.1.2
 validationVersion=2.0.1.Final
 jcacheVersion=1.1.0
-micronautVersion=1.0.4
+micronautVersion=1.1.0
 micronautTestVersion=1.0.2
 protocVersion=3.5.1
 groovyVersion=2.5.6

--- a/hibernate-jpa/src/test/groovy/io/micronaut/configuration/hibernate/jpa/JpaSetupSpec.groovy
+++ b/hibernate-jpa/src/test/groovy/io/micronaut/configuration/hibernate/jpa/JpaSetupSpec.groovy
@@ -15,7 +15,6 @@
  */
 package io.micronaut.configuration.hibernate.jpa
 
-import io.micrometer.core.instrument.Counter
 import io.micrometer.core.instrument.FunctionCounter
 import io.micrometer.core.instrument.MeterRegistry
 import io.micronaut.configuration.hibernate.jpa.scope.CurrentSession
@@ -30,7 +29,6 @@ import io.micronaut.spring.tx.annotation.BindableRuleBasedTransactionAttribute
 import io.micronaut.spring.tx.annotation.TransactionInterceptor
 import io.micronaut.spring.tx.annotation.Transactional
 import org.hibernate.Session
-import org.hibernate.SessionFactory
 import org.springframework.transaction.TransactionDefinition
 import org.springframework.transaction.annotation.Isolation
 import org.springframework.transaction.annotation.Propagation
@@ -150,7 +148,7 @@ class JpaSetupSpec extends Specification {
         bookService.saveError()
 
         then:
-        def e  = thrown(RuntimeException)
+        def e  = thrown(Exception)
 
         when:
         books = bookService.listBooks()


### PR DESCRIPTION
## Background

When running as native-image, `environment.scan` doesn't work. It is one of the reasons we can't get `EntityManager` which needs `Entity` scan with the `environment.scan` in `EntityManagerFactoryBean`.

## Solution

Provide an option for `Entity` scan to use `BeanIntrospector` instead of `environment.scan`

## Changes

1. Change to use Micronaut 1.1.0 to use `BeanIntrospector`
2. Provide an option to use `BeanIntrospector` instead of `environment.scan`

## Related Issues

* https://github.com/micronaut-projects/micronaut-sql/issues/9
* https://github.com/micronaut-projects/micronaut-core/issues/1569
* https://github.com/micronaut-projects/micronaut-sql/issues/8