### PR TITLE
Make DataSource initialization eager

### DIFF
--- a/jdbc-dbcp/src/main/java/io/micronaut/configuration/jdbc/dbcp/DatasourceConfiguration.java
+++ b/jdbc-dbcp/src/main/java/io/micronaut/configuration/jdbc/dbcp/DatasourceConfiguration.java
@@ -16,6 +16,7 @@
 
 package io.micronaut.configuration.jdbc.dbcp;
 
+import io.micronaut.context.annotation.Context;
 import io.micronaut.context.annotation.EachProperty;
 import io.micronaut.context.annotation.Parameter;
 import io.micronaut.jdbc.BasicJdbcConfiguration;
@@ -38,6 +39,7 @@ import java.sql.SQLException;
  * @author James Kleeh
  * @since 1.0
  */
+@Context
 @EachProperty(value = BasicJdbcConfiguration.PREFIX, primary = "default")
 public class DatasourceConfiguration extends BasicDataSource implements BasicJdbcConfiguration {
 

--- a/jdbc-hikari/src/main/java/io/micronaut/configuration/jdbc/hikari/DatasourceFactory.java
+++ b/jdbc-hikari/src/main/java/io/micronaut/configuration/jdbc/hikari/DatasourceFactory.java
@@ -18,6 +18,7 @@ package io.micronaut.configuration.jdbc.hikari;
 
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micronaut.context.ApplicationContext;
+import io.micronaut.context.annotation.Context;
 import io.micronaut.context.annotation.EachBean;
 import io.micronaut.context.annotation.Factory;
 import org.slf4j.Logger;
@@ -60,6 +61,7 @@ public class DatasourceFactory implements AutoCloseable {
      * @param datasourceConfiguration A {@link DatasourceConfiguration}
      * @return A {@link HikariUrlDataSource}
      */
+    @Context
     @EachBean(DatasourceConfiguration.class)
     public DataSource dataSource(DatasourceConfiguration datasourceConfiguration) {
         HikariUrlDataSource ds = new HikariUrlDataSource(datasourceConfiguration);

--- a/jdbc-tomcat/src/main/java/io/micronaut/configuration/jdbc/tomcat/DatasourceFactory.java
+++ b/jdbc-tomcat/src/main/java/io/micronaut/configuration/jdbc/tomcat/DatasourceFactory.java
@@ -18,6 +18,7 @@ package io.micronaut.configuration.jdbc.tomcat;
 
 import javax.annotation.Nullable;
 import io.micronaut.configuration.jdbc.tomcat.metadata.TomcatDataSourcePoolMetadata;
+import io.micronaut.context.annotation.Context;
 import io.micronaut.context.annotation.EachBean;
 import io.micronaut.context.annotation.Factory;
 import io.micronaut.context.annotation.Requires;
@@ -57,6 +58,7 @@ public class DatasourceFactory implements AutoCloseable {
      * @param datasourceConfiguration A {@link DatasourceConfiguration}
      * @return An Apache Tomcat {@link DataSource}
      */
+    @Context
     @EachBean(DatasourceConfiguration.class)
     public DataSource dataSource(DatasourceConfiguration datasourceConfiguration) {
         org.apache.tomcat.jdbc.pool.DataSource ds = new org.apache.tomcat.jdbc.pool.DataSource(datasourceConfiguration);


### PR DESCRIPTION
Make the `DataSource` initialization eager for the three pools: hikari, tomcat and dbcp.

The rationale behind this change is:
- Allow Flyway and Liquibase database migrations run without JPA configuration. At this moment we need at least one class annotated with `@javax.persistence.Entity` to trigger the execution. This only works if JPA is defined because it is loaded eager: https://github.com/micronaut-projects/micronaut-sql/blob/33bb9f6fcbec2696ab668bec0ab9a6ed28a46e55/hibernate-jpa/src/main/java/io/micronaut/configuration/hibernate/jpa/EntityManagerFactoryBean.java#L166
- A user opened an issue because he had a CLI application (without JPA) to run the migrations (only datasource config and migrations). His workaround was injecting `DataSource` somewhere to make it run eagerly.
- If we wait 1 minute after an application starts the migrations will run because of https://github.com/micronaut-projects/micronaut-core/blob/afc3fb377fea37f942c1a251be19b58f9f989b22/management/src/main/java/io/micronaut/management/health/monitor/HealthMonitorTask.java#L81. The `JdbcIndicator` needs the `DataSource`s and creating them will trigger the Flyway/Liquibase migrations.
- Finally, I think it makes sense to initialize the datasources eagerly because if there is an error it's better to have it during application startup than later when the datasource is used.