### PR TITLE
update postgres-reactive to vertx-pg-client

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 projectVersion=1.2.0.BUILD-SNAPSHOT
-reactivePgClientVersion=0.11.3
+reactivePgClientVersion=3.8.0
 jasyncClientVersion=0.9.51
 kafkaVersion=2.1.0
 micronautDocsVersion=1.0.2

--- a/postgres-reactive/build.gradle
+++ b/postgres-reactive/build.gradle
@@ -1,27 +1,27 @@
 dependencies {
     annotationProcessor "io.micronaut:micronaut-inject-java"
-    annotationProcessor "io.micronaut.docs:micronaut-docs-asciidoc-config-props:$micronautDocsVersion"    
+    annotationProcessor "io.micronaut.docs:micronaut-docs-asciidoc-config-props:$micronautDocsVersion"
 
     compile "io.micronaut:micronaut-inject:$micronautVersion"
-    compile "io.reactiverse:reactive-pg-client:$reactivePgClientVersion"
+    compile "io.vertx:vertx-pg-client:$reactivePgClientVersion"
     compileOnly "io.micronaut:micronaut-management:$micronautVersion"
-    
-    compile "io.vertx:vertx-rx-java2:3.6.2", {
+
+    compile "io.vertx:vertx-rx-java2:3.8.0", {
         exclude module: "vertx-core"
     }
-    compile "io.vertx:vertx-codegen:3.6.2", {
+    compile "io.vertx:vertx-codegen:3.8.0", {
         exclude module: "vertx-core"
     }
 
 
-    testCompile "io.reactiverse:reactive-pg-client:$reactivePgClientVersion"
+    testCompile "io.vertx:vertx-pg-client:$reactivePgClientVersion"
     testCompile "io.micronaut:micronaut-management:$micronautVersion"
     testCompile "org.testcontainers:spock:1.10.1"
     testCompile "org.testcontainers:postgresql:1.10.1"
-    testCompile "io.vertx:vertx-rx-java2:3.5.3", {
+    testCompile "io.vertx:vertx-rx-java2:3.8.0", {
         exclude module: "vertx-core"
     }
-    testCompile "io.vertx:vertx-codegen:3.5.3", {
+    testCompile "io.vertx:vertx-codegen:3.8.0", {
         exclude module: "vertx-core"
     }
 }

--- a/postgres-reactive/src/main/java/io/micronaut/configuration/postgres/reactive/PgPoolClientFactory.java
+++ b/postgres-reactive/src/main/java/io/micronaut/configuration/postgres/reactive/PgPoolClientFactory.java
@@ -19,9 +19,10 @@ package io.micronaut.configuration.postgres.reactive;
 import io.micronaut.context.annotation.Bean;
 import io.micronaut.context.annotation.Factory;
 import io.micronaut.core.util.StringUtils;
-import io.reactiverse.reactivex.pgclient.PgClient;
-import io.reactiverse.reactivex.pgclient.PgPool;
+import io.vertx.pgclient.PgConnectOptions;
+import io.vertx.pgclient.PgPool;
 import io.vertx.reactivex.core.Vertx;
+import io.vertx.sqlclient.PoolOptions;
 
 import javax.annotation.Nullable;
 import javax.inject.Singleton;
@@ -77,9 +78,11 @@ public class PgPoolClientFactory {
 
         String connectionUri = configuration.getUri();
         if (StringUtils.isNotEmpty(connectionUri)) {
-            return PgClient.pool(connectionUri);
+            return PgPool.pool(connectionUri);
         } else {
-            return PgClient.pool(configuration.pgPoolOptions);
+            PgConnectOptions connectOptions = new PgConnectOptions(configuration.pgConnectOptions);
+            PoolOptions poolOptions = new PoolOptions();
+            return PgPool.pool(connectOptions,poolOptions);
         }
     }
 
@@ -94,9 +97,11 @@ public class PgPoolClientFactory {
 
         String connectionUri = configuration.getUri();
         if (StringUtils.isNotEmpty(connectionUri)) {
-            return PgClient.pool(vertx, connectionUri);
+            return PgPool.pool(connectionUri);
         } else {
-            return PgClient.pool(vertx, configuration.pgPoolOptions);
+            PgConnectOptions connectOptions = new PgConnectOptions(configuration.pgConnectOptions);
+            PoolOptions poolOptions = new PoolOptions();
+            return PgPool.pool(vertx.getDelegate(),connectOptions,poolOptions);
         }
     }
 }

--- a/postgres-reactive/src/main/java/io/micronaut/configuration/postgres/reactive/PgPoolConfiguration.java
+++ b/postgres-reactive/src/main/java/io/micronaut/configuration/postgres/reactive/PgPoolConfiguration.java
@@ -18,7 +18,8 @@ package io.micronaut.configuration.postgres.reactive;
 
 import io.micronaut.context.annotation.ConfigurationBuilder;
 import io.micronaut.context.annotation.ConfigurationProperties;
-import io.reactiverse.pgclient.PgPoolOptions;
+import io.vertx.pgclient.PgConnectOptions;
+import io.vertx.sqlclient.PoolOptions;
 
 /**
  * The configuration class for Reactive Postgres Client.
@@ -30,7 +31,10 @@ import io.reactiverse.pgclient.PgPoolOptions;
 public class PgPoolConfiguration {
 
     @ConfigurationBuilder
-    protected PgPoolOptions pgPoolOptions = new PgPoolOptions();
+    protected PgConnectOptions pgConnectOptions = new PgConnectOptions();
+    @ConfigurationBuilder
+    protected PoolOptions pgPoolOptions = new PoolOptions();
+
     protected String uri;
 
     /**
@@ -42,9 +46,17 @@ public class PgPoolConfiguration {
 
     /**
      *
-     * @return The options for configuring a connection pool.
+     * @return The options for configuring a pool.
      */
-    public PgPoolOptions getPgPoolOptions() {
+    public PoolOptions getPgPoolOptions() {
         return pgPoolOptions;
+    }
+
+    /**
+     *
+     * @return The options for configuring a connection.
+     */
+    public PgConnectOptions getPgConnectOptions() {
+        return pgConnectOptions;
     }
 }

--- a/postgres-reactive/src/main/java/io/micronaut/configuration/postgres/reactive/condition/RequiresReactivePgClient.java
+++ b/postgres-reactive/src/main/java/io/micronaut/configuration/postgres/reactive/condition/RequiresReactivePgClient.java
@@ -18,7 +18,8 @@ package io.micronaut.configuration.postgres.reactive.condition;
 
 import io.micronaut.configuration.postgres.reactive.PgPoolClientSettings;
 import io.micronaut.context.annotation.Requires;
-import io.reactiverse.pgclient.PgPoolOptions;
+import io.vertx.pgclient.PgConnectOptions;
+import io.vertx.sqlclient.PoolOptions;
 
 import java.lang.annotation.*;
 
@@ -30,6 +31,6 @@ import java.lang.annotation.*;
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.PACKAGE, ElementType.TYPE})
 @Requires(property = PgPoolClientSettings.PREFIX)
-@Requires(classes = {PgPoolOptions.class})
+@Requires(classes = {PgConnectOptions.class, PoolOptions.class})
 public @interface RequiresReactivePgClient {
 }

--- a/postgres-reactive/src/main/java/io/micronaut/configuration/postgres/reactive/health/PgPoolHealthIndicator.java
+++ b/postgres-reactive/src/main/java/io/micronaut/configuration/postgres/reactive/health/PgPoolHealthIndicator.java
@@ -22,8 +22,8 @@ import io.micronaut.health.HealthStatus;
 import io.micronaut.management.endpoint.health.HealthEndpoint;
 import io.micronaut.management.health.indicator.HealthIndicator;
 import io.micronaut.management.health.indicator.HealthResult;
-import io.reactiverse.reactivex.pgclient.PgPool;
-import io.reactiverse.reactivex.pgclient.Row;
+import io.vertx.reactivex.pgclient.PgPool;
+import io.vertx.reactivex.sqlclient.Row;
 import org.reactivestreams.Publisher;
 
 import javax.inject.Singleton;
@@ -55,6 +55,7 @@ public class PgPoolHealthIndicator implements HealthIndicator {
 
     @Override
     public Publisher<HealthResult> getResult() {
+
         return client.rxQuery(QUERY)
                 .map(pgRowSet -> {
                     HealthResult.Builder status = HealthResult.builder(NAME, HealthStatus.UP);

--- a/postgres-reactive/src/test/groovy/io/micronaut/configuration/postgres/reactive/PgPoolConfigurationSpec.groovy
+++ b/postgres-reactive/src/test/groovy/io/micronaut/configuration/postgres/reactive/PgPoolConfigurationSpec.groovy
@@ -34,17 +34,18 @@ class PgPoolConfigurationSpec extends Specification {
                 'postgres.reactive.client.database': 'the-db',
                 'postgres.reactive.client.user': 'user',
                 'postgres.reactive.client.password': 'secret',
-                'postgres.reactive.client.maxSize': '5'
+                'postgres.reactive.pool.maxSize': '5'
         )
 
         then:
         applicationContext.containsBean(PgPoolConfiguration)
+        applicationContext.getBean(PgPoolConfiguration).pgConnectOptions
         applicationContext.getBean(PgPoolConfiguration).pgPoolOptions
-        applicationContext.getBean(PgPoolConfiguration).pgPoolOptions.port == 5432
-        applicationContext.getBean(PgPoolConfiguration).pgPoolOptions.host == 'the-host'
-        applicationContext.getBean(PgPoolConfiguration).pgPoolOptions.database == 'the-db'
-        applicationContext.getBean(PgPoolConfiguration).pgPoolOptions.user == 'user'
-        applicationContext.getBean(PgPoolConfiguration).pgPoolOptions.password == 'secret'
+        applicationContext.getBean(PgPoolConfiguration).pgConnectOptions.port == 5432
+        applicationContext.getBean(PgPoolConfiguration).pgConnectOptions.host == 'the-host'
+        applicationContext.getBean(PgPoolConfiguration).pgConnectOptions.database == 'the-db'
+        applicationContext.getBean(PgPoolConfiguration).pgConnectOptions.user == 'user'
+        applicationContext.getBean(PgPoolConfiguration).pgConnectOptions.password == 'secret'
         applicationContext.getBean(PgPoolConfiguration).pgPoolOptions.maxSize == 5
 
 

--- a/postgres-reactive/src/test/groovy/io/micronaut/configuration/postgres/reactive/PostgresReactiveSpec.groovy
+++ b/postgres-reactive/src/test/groovy/io/micronaut/configuration/postgres/reactive/PostgresReactiveSpec.groovy
@@ -19,9 +19,10 @@ package io.micronaut.configuration.postgres.reactive
 //tag::appcontext-import[]
 import io.micronaut.context.ApplicationContext
 //end::appcontext-import[]
-import io.reactiverse.reactivex.pgclient.PgIterator
-import io.reactiverse.reactivex.pgclient.PgPool
-import io.reactiverse.reactivex.pgclient.PgRowSet
+import io.vertx.reactivex.pgclient.PgPool
+import io.vertx.reactivex.sqlclient.RowIterator
+import io.vertx.reactivex.sqlclient.RowSet
+
 //tag::pg-testcontainer-import[]
 import org.testcontainers.containers.PostgreSQLContainer
 //end::pg-testcontainer-import[]
@@ -52,7 +53,7 @@ class PostgresReactiveSpec extends Specification {
                 'postgres.reactive.client.database': postgres.databaseName,
                 'postgres.reactive.client.user': postgres.username,
                 'postgres.reactive.client.password': postgres.password,
-                'postgres.reactive.client.maxSize': '5'
+                'postgres.reactive.pool.maxSize': '5'
         )
 
         //end::pg-client-conf[]
@@ -65,9 +66,9 @@ class PostgresReactiveSpec extends Specification {
         // end::pgPool-bean[]
 
         // tag::query[]
-        result = client.rxQuery('SELECT * FROM pg_stat_database').map({ PgRowSet pgRowSet -> // <1>
+        result = client.rxQuery('SELECT * FROM pg_stat_database').map({ RowSet pgRowSet -> // <1>
             int size = 0
-            PgIterator iterator = pgRowSet.iterator()
+            RowIterator iterator = pgRowSet.iterator()
             while (iterator.hasNext()) {
                 iterator.next()
                 size++

--- a/postgres-reactive/src/test/groovy/io/micronaut/configuration/postgres/reactive/health/PgPoolHealthIndicatorSpec.groovy
+++ b/postgres-reactive/src/test/groovy/io/micronaut/configuration/postgres/reactive/health/PgPoolHealthIndicatorSpec.groovy
@@ -40,7 +40,7 @@ class PgPoolHealthIndicatorSpec extends Specification {
                 'postgres.reactive.client.database': postgres.databaseName,
                 'postgres.reactive.client.user': postgres.username,
                 'postgres.reactive.client.password': postgres.password,
-                'postgres.reactive.client.maxSize': '5'
+                'postgres.reactive.client.pool': '5'
         )
 
         when:


### PR DESCRIPTION
Postgres-reactive has been changed to vertx-pg-client
See:[https://vertx.io/docs/vertx-pg-client](https://vertx.io/docs/vertx-pg-client)

