### PR TITLE
jasync health check failing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,7 @@ subprojects { Project subproject ->
     repositories {
         jcenter()
     }
-    
+
     apply plugin:"groovy"
     apply plugin:"java-library"
     apply plugin: "io.spring.nohttp"
@@ -54,7 +54,7 @@ subprojects { Project subproject ->
     sourceCompatibility = '1.8'
     targetCompatibility = '1.8'
     apply from:"https://raw.githubusercontent.com/micronaut-projects/micronaut-build/v${micronautBuildVersion}/publishing.gradle"
-        
+
 
     jar {
         manifest {
@@ -101,13 +101,13 @@ subprojects { Project subproject ->
         documentation "org.codehaus.groovy:groovy-templates:$groovyVersion"
         documentation "org.codehaus.groovy:groovy-dateutil:$groovyVersion"
 
-        testCompile platform("io.micronaut:micronaut-bom:$micronautVersion")
-        testCompile "io.micronaut:micronaut-http-client"
-        testCompile "io.micronaut:micronaut-runtime"
-        testCompile "io.micronaut:micronaut-http-server-netty"
+        testImplementation platform("io.micronaut:micronaut-bom:$micronautVersion")
+        testImplementation "io.micronaut:micronaut-http-client"
+        testImplementation "io.micronaut:micronaut-runtime"
+        testImplementation "io.micronaut:micronaut-http-server-netty"
 
-        testCompile "cglib:cglib-nodep:3.3.0"
-        testCompile "org.objenesis:objenesis:3.1"
+        testImplementation "cglib:cglib-nodep:3.3.0"
+        testImplementation "org.objenesis:objenesis:3.1"
 
         testImplementation("org.spockframework:spock-core:${spockVersion}") {
             exclude module:'groovy-all'

--- a/build.gradle
+++ b/build.gradle
@@ -101,8 +101,13 @@ subprojects { Project subproject ->
         documentation "org.codehaus.groovy:groovy-templates:$groovyVersion"
         documentation "org.codehaus.groovy:groovy-dateutil:$groovyVersion"
 
-        testImplementation "cglib:cglib-nodep:3.3.0"
-        testImplementation "org.objenesis:objenesis:3.1"
+        testCompile platform("io.micronaut:micronaut-bom:$micronautVersion")
+        testCompile "io.micronaut:micronaut-http-client"
+        testCompile "io.micronaut:micronaut-runtime"
+        testCompile "io.micronaut:micronaut-http-server-netty"
+
+        testCompile "cglib:cglib-nodep:3.3.0"
+        testCompile "org.objenesis:objenesis:3.1"
 
         testImplementation("org.spockframework:spock-core:${spockVersion}") {
             exclude module:'groovy-all'


### PR DESCRIPTION
We started using jasync in our project and the default health check always results in a timeout.
We had to implement our own. 
I think there is an issue with the ` s.onNext(status.build());` being subscribed on. 
I wrote a failing test using the `EmbeddedServer` against the existing code.
I then modified the existing health check to pass that failing test.

I'd like to clean this all up with a :bowtie:,  but I wanted to get some feedback on using the `EmbeddedServer` for testing in this project and the overall approach.