### PR TITLE
Add logging of Hibernate errors.

### DIFF
--- a/hibernate-jpa/src/main/java/io/micronaut/configuration/hibernate/jpa/EntityManagerFactoryBean.java
+++ b/hibernate-jpa/src/main/java/io/micronaut/configuration/hibernate/jpa/EntityManagerFactoryBean.java
@@ -189,13 +189,13 @@ public class EntityManagerFactoryBean {
             }
             return sessionFactoryBuilder;
         } catch (MappingException e) {
-            if (LOG.isWarnEnabled()) {
-                LOG.warn("Hibernate mapping error", e);
+            if (LOG.isErrorEnabled()) {
+                LOG.error("Hibernate mapping error", e);
             }
             throw e;
         } catch (Exception e) {
-            if (LOG.isWarnEnabled()) {
-                LOG.warn("Error creating SessionFactoryBuilder", e);
+            if (LOG.isErrorEnabled()) {
+                LOG.error("Error creating SessionFactoryBuilder", e);
             }
             throw e;
         }


### PR DESCRIPTION
See issue 165 for a description of the problem.

Notes:
- what should the log level be?
- I've split out different messages for mapping exceptions vs. all others. Not necessary but maybe useful.
- changed Class to Class<?> just to get rid of warnings.

The 'environment' attribute isn't used - can it be removed? I didn't look into it.
 