### PR TITLE
Support newer versions of SQL Server driver in GraalVM

### DIFF
--- a/jdbc/src/main/java/io/micronaut/jdbc/nativeimage/JdbcFeature.java
+++ b/jdbc/src/main/java/io/micronaut/jdbc/nativeimage/JdbcFeature.java
@@ -181,6 +181,8 @@ final class JdbcFeature implements Feature {
 
             RuntimeClassInitialization.initializeAtBuildTime(SQL_SERVER_DRIVER);
 
+            initializeAtBuildTime(access, "com.microsoft.sqlserver.jdbc.Util");
+            initializeAtBuildTime(access, "com.microsoft.sqlserver.jdbc.SQLServerException");
             registerAllIfPresent(access, "com.microsoft.sqlserver.jdbc.SQLServerDriver");
 
             ResourcesRegistry resourcesRegistry = getResourceRegistry();


### PR DESCRIPTION
I've been using `'com.microsoft.sqlserver:mssql-jdbc:7.4.1.jre8'` driver for my tests but after updating to `8.2.2.jre8` these changes are necessary (they are backward compatible with the old driver)