### PR TITLE
Add GraalVM support for latest Postgresql driver

### DIFF
--- a/jdbc/src/main/java/io/micronaut/jdbc/nativeimage/JdbcFeature.java
+++ b/jdbc/src/main/java/io/micronaut/jdbc/nativeimage/JdbcFeature.java
@@ -91,6 +91,8 @@ final class JdbcFeature implements Feature {
                     "org.postgresql.util.SharedTimer"
             );
 
+            registerAllFields(access, "org.postgresql.PGProperty");
+
             ResourcesRegistry resourcesRegistry = getResourceRegistry();
             if (resourcesRegistry != null) {
                 resourcesRegistry.addResources("META-INF/services/java.sql.Driver");
@@ -185,6 +187,16 @@ final class JdbcFeature implements Feature {
         Field[] fields = t.getFields();
         for (Field field : fields) {
             RuntimeReflection.register(field);
+        }
+    }
+
+    private void registerAllFields(BeforeAnalysisAccess access, String n) {
+        Class<?> t = access.findClassByName(n);
+        if (t != null) {
+            Field[] fields = t.getFields();
+            for (Field field : fields) {
+                RuntimeReflection.register(field);
+            }
         }
     }
 


### PR DESCRIPTION
With the inclusion in BOM of the latest versions of sql drivers, the GraalVM Postgresql apps started to fail:
- JBDC: https://gitlab.com/micronaut-projects/micronaut-graal-tests/-/jobs/586681056
- JPA: https://gitlab.com/micronaut-projects/micronaut-graal-tests/-/jobs/586681067

This PR adds support for the latest version of the Postgresql driver.