### PR TITLE
Add jakarta.persistence-api dependency

### DIFF
--- a/jooq/build.gradle
+++ b/jooq/build.gradle
@@ -19,6 +19,9 @@ dependencies {
     compileOnly "org.graalvm.nativeimage:svm"
     testCompileOnly "io.micronaut:micronaut-inject-java"
 
+    // needed for native image (adding @Entity annotation to UpdatableRecords for reflection registration)
+    implementation "jakarta.persistence:jakarta.persistence-api:2.2.2"
+
     api "io.micronaut:micronaut-jdbc:$micronautVersion"
     api "io.micronaut:micronaut-inject:$micronautVersion"
     api "org.jooq:jooq:3.13.2"


### PR DESCRIPTION
Needed for native image (adding `@Entity` annotation to `UpdatableRecord`s for reflection registration).

@ilopmar We should remove this from https://github.com/micronaut-graal-tests/micronaut-jooq-graal if this will be merged. 