### PR TITLE
Initialize substituted class at build time

### DIFF
--- a/jooq/src/main/resources/META-INF/native-image/io.micronaut.configuration/jooq-graal/native-image.properties
+++ b/jooq/src/main/resources/META-INF/native-image/io.micronaut.configuration/jooq-graal/native-image.properties
@@ -15,4 +15,5 @@
 #
 
 Args = -H:ClassInitialization=org.jooq.SQLDialect$ThirdParty:build_time \
-       --initialize-at-run-time=io.micronaut.configuration.jooq.spring.SpringTransactionProvider,io.micronaut.configuration.jooq.spring.JooqExceptionTranslator
+       --initialize-at-run-time=io.micronaut.configuration.jooq.spring.SpringTransactionProvider,io.micronaut.configuration.jooq.spring.JooqExceptionTranslator \
+       --initialize-at-build-time=org.simpleflatmapper.reflect.DefaultReflectionService


### PR DESCRIPTION
Otherwise this error is happening at building native image:

```
Error: Classes that should be initialized at run time got initialized during image building:
 org.simpleflatmapper.reflect.DefaultReflectionService was unintentionally initialized at build time. org.simpleflatmapper.reflect.DefaultReflectionService has been initialized without the native-image initialization instrumentation and the stack trace can't be tracked. Try marking this class for build-time initialization with --initialize-at-build-time=org.simpleflatmapper.reflect.DefaultReflectionService
```

It is needed after my PR https://github.com/micronaut-projects/micronaut-sql/pull/218 was merged.
Sorry for those troubles.