### PR TITLE
MySQL needs DriverManager initialized at Runtime for GraalVM

### DIFF
--- a/jdbc/src/main/java/io/micronaut/jdbc/nativeimage/JdbcFeature.java
+++ b/jdbc/src/main/java/io/micronaut/jdbc/nativeimage/JdbcFeature.java
@@ -311,7 +311,7 @@ final class JdbcFeature implements Feature {
                 resourcesRegistry.addResourceBundles("com.mysql.cj.LocalizedErrorMessages");
             }
 
-            initializeAtBuildTime(access, "java.sql.DriverManager");
+            initializeAtRuntime(access, "java.sql.DriverManager");
         }
     }
 


### PR DESCRIPTION
I missed this case on #250. MySQL is the only driver that needs initialize `java.sql.DriverManager` at runtime. All the drivers work with build-time initialization.

See https://github.com/micronaut-projects/micronaut-core/issues/3713