### PR TITLE
Hibernate JPA support for additional XML mapping resources

### DIFF
--- a/hibernate-jpa/src/main/java/io/micronaut/configuration/hibernate/jpa/EntityManagerFactoryBean.java
+++ b/hibernate-jpa/src/main/java/io/micronaut/configuration/hibernate/jpa/EntityManagerFactoryBean.java
@@ -161,6 +161,13 @@ public class EntityManagerFactoryBean {
         MetadataSources metadataSources = createMetadataSources(standardServiceRegistry);
         JpaConfiguration.EntityScanConfiguration entityScanConfiguration = jpaConfiguration.getEntityScanConfiguration();
         entityScanConfiguration.findEntities().forEach(metadataSources::addAnnotatedClass);
+
+        if (jpaConfiguration.getMappingResources() != null) {
+            for (String resource : jpaConfiguration.getMappingResources()) {
+                metadataSources.addResource(resource);
+            }
+        }
+
         return metadataSources;
     }
 

--- a/hibernate-jpa/src/main/java/io/micronaut/configuration/hibernate/jpa/JpaConfiguration.java
+++ b/hibernate-jpa/src/main/java/io/micronaut/configuration/hibernate/jpa/JpaConfiguration.java
@@ -53,6 +53,7 @@ public class JpaConfiguration {
     private final Environment environment;
     private final ApplicationContext applicationContext;
     private Map<String, Object> jpaProperties = new HashMap<>(10);
+    private List<String> mappingResources = new ArrayList<>();
     private EntityScanConfiguration entityScanConfiguration;
 
     /**
@@ -189,6 +190,22 @@ public class JpaConfiguration {
         return new StandardServiceRegistryBuilder(
                 bootstrapServiceRegistry
         );
+    }
+
+    /**
+     * Mapping resources (equivalent to "mapping-file" entries in persistence.xml).
+     */
+    public List<String> getMappingResources() {
+        return this.mappingResources;
+    }
+
+    /**
+     * Sets additional mapping resources.
+     *
+     * @param mappingResources list of mapping files
+     */
+    public void setMappingResources(List<String> mappingResources) {
+        this.mappingResources = mappingResources;
     }
 
     /**

--- a/hibernate-jpa/src/test/groovy/io/micronaut/configuration/hibernate/jpa/JpaConfigurationSpec.groovy
+++ b/hibernate-jpa/src/test/groovy/io/micronaut/configuration/hibernate/jpa/JpaConfigurationSpec.groovy
@@ -55,4 +55,21 @@ class JpaConfigurationSpec extends Specification {
         cleanup:
         ctx?.close()
     }
+
+    void "test mapping resources"() {
+        given:
+        def ctx = ApplicationContext.run(
+                'jpa.default.mapping-resources': ['hibernate/custom.hbm.xml']
+        )
+
+        def config = ctx.getBean(JpaConfiguration)
+
+        expect:
+        config.mappingResources
+        config.mappingResources == ['hibernate/custom.hbm.xml']
+
+        cleanup:
+        ctx?.close()
+    }
+
 }

--- a/hibernate-jpa/src/test/groovy/io/micronaut/configuration/hibernate/jpa/mapping/Account.java
+++ b/hibernate-jpa/src/test/groovy/io/micronaut/configuration/hibernate/jpa/mapping/Account.java
@@ -1,0 +1,58 @@
+package io.micronaut.configuration.hibernate.jpa.mapping;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import javax.validation.constraints.NotBlank;
+
+@Entity
+@Table(name = "account")
+public class Account {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private Long id;
+
+    @Column(name = "username", nullable = false)
+    @NotBlank
+    private String username;
+
+    @Column(name = "password", nullable = false)
+    @NotBlank
+    private String password;
+
+    public Account() {
+    }
+
+    public Account(String username, String password) {
+        this.username = username;
+        this.password = password;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+}

--- a/hibernate-jpa/src/test/groovy/io/micronaut/configuration/hibernate/jpa/mapping/Account.java
+++ b/hibernate-jpa/src/test/groovy/io/micronaut/configuration/hibernate/jpa/mapping/Account.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.micronaut.configuration.hibernate.jpa.mapping;
 
 import javax.persistence.Column;

--- a/hibernate-jpa/src/test/groovy/io/micronaut/configuration/hibernate/jpa/mapping/AccountRepository.java
+++ b/hibernate-jpa/src/test/groovy/io/micronaut/configuration/hibernate/jpa/mapping/AccountRepository.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.micronaut.configuration.hibernate.jpa.mapping;
 
 import edu.umd.cs.findbugs.annotations.Nullable;

--- a/hibernate-jpa/src/test/groovy/io/micronaut/configuration/hibernate/jpa/mapping/AccountRepository.java
+++ b/hibernate-jpa/src/test/groovy/io/micronaut/configuration/hibernate/jpa/mapping/AccountRepository.java
@@ -1,0 +1,35 @@
+package io.micronaut.configuration.hibernate.jpa.mapping;
+
+import edu.umd.cs.findbugs.annotations.Nullable;
+import io.micronaut.configuration.hibernate.jpa.scope.CurrentSession;
+import io.micronaut.transaction.annotation.TransactionalAdvice;
+
+import javax.inject.Singleton;
+import javax.persistence.EntityManager;
+import javax.validation.constraints.NotBlank;
+
+@TransactionalAdvice
+@Singleton
+public class AccountRepository {
+
+    private final EntityManager entityManager;
+
+    public AccountRepository(@CurrentSession EntityManager entityManager) {
+        this.entityManager = entityManager;
+    }
+
+    public Account create(@NotBlank String username, @NotBlank String password) {
+        Account account = new Account(username, password);
+        entityManager.persist(account);
+        return account;
+    }
+
+    @Nullable
+    public Account findByUsername(String username) {
+        return (Account) entityManager
+                .createNativeQuery("SELECT * FROM custom_view WHERE username = :username", Account.class)
+                .setParameter("username", username)
+                .getSingleResult();
+    }
+
+}

--- a/hibernate-jpa/src/test/groovy/io/micronaut/configuration/hibernate/jpa/mapping/CustomIndexesDatabaseObject.java
+++ b/hibernate-jpa/src/test/groovy/io/micronaut/configuration/hibernate/jpa/mapping/CustomIndexesDatabaseObject.java
@@ -1,0 +1,18 @@
+package io.micronaut.configuration.hibernate.jpa.mapping;
+
+import org.hibernate.boot.model.relational.AbstractAuxiliaryDatabaseObject;
+import org.hibernate.dialect.Dialect;
+
+public class CustomIndexesDatabaseObject extends AbstractAuxiliaryDatabaseObject {
+
+    @Override
+    public String[] sqlCreateStrings(Dialect dialect) {
+        return new String[]{"CREATE VIEW custom_view AS SELECT * FROM account"};
+    }
+
+    @Override
+    public String[] sqlDropStrings(Dialect dialect) {
+        return new String[]{"DROP VIEW IF EXISTS custom_view"};
+    }
+
+}

--- a/hibernate-jpa/src/test/groovy/io/micronaut/configuration/hibernate/jpa/mapping/CustomIndexesDatabaseObject.java
+++ b/hibernate-jpa/src/test/groovy/io/micronaut/configuration/hibernate/jpa/mapping/CustomIndexesDatabaseObject.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.micronaut.configuration.hibernate.jpa.mapping;
 
 import org.hibernate.boot.model.relational.AbstractAuxiliaryDatabaseObject;

--- a/hibernate-jpa/src/test/groovy/io/micronaut/configuration/hibernate/jpa/mapping/MappingResourcesSpec.groovy
+++ b/hibernate-jpa/src/test/groovy/io/micronaut/configuration/hibernate/jpa/mapping/MappingResourcesSpec.groovy
@@ -1,0 +1,42 @@
+package io.micronaut.configuration.hibernate.jpa.mapping
+
+import io.micronaut.context.ApplicationContext
+import org.hibernate.boot.MetadataSources
+import org.hibernate.boot.jaxb.SourceType
+import org.hibernate.boot.jaxb.hbm.spi.JaxbHbmHibernateMapping
+import spock.lang.Specification
+
+class MappingResourcesSpec extends Specification {
+
+    void "test custom mapping resources initialization"() {
+        given:
+        def context = ApplicationContext.run(
+                'datasources.default.name': 'test',
+                'jpa.default.entity-scan.packages': ['io.micronaut.configuration.hibernate.jpa.mapping'],
+                'jpa.default.properties.hibernate.hbm2ddl.auto': 'create-drop',
+                'jpa.default.mapping-resources': ['hibernate/custom.hbm.xml']
+        )
+
+        when:
+        MetadataSources metadataSources = context.getBean(MetadataSources)
+
+        then:
+        metadataSources.xmlBindings
+        metadataSources.xmlBindings.size() == 1
+        metadataSources.xmlBindings[0].root instanceof JaxbHbmHibernateMapping
+        metadataSources.xmlBindings[0].origin.type == SourceType.RESOURCE
+        metadataSources.xmlBindings[0].origin.name == 'hibernate/custom.hbm.xml'
+
+        when:
+        AccountRepository accountRepository = context.getBean(AccountRepository)
+        accountRepository.create("test", "test")
+        Account testAccount = accountRepository.findByUsername("test")
+
+        then:
+        testAccount
+        testAccount.username == "test"
+
+        cleanup:
+        context.close()
+    }
+}

--- a/hibernate-jpa/src/test/groovy/io/micronaut/configuration/hibernate/jpa/mapping/MappingResourcesSpec.groovy
+++ b/hibernate-jpa/src/test/groovy/io/micronaut/configuration/hibernate/jpa/mapping/MappingResourcesSpec.groovy
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.micronaut.configuration.hibernate.jpa.mapping
 
 import io.micronaut.context.ApplicationContext

--- a/hibernate-jpa/src/test/resources/hibernate/custom.hbm.xml
+++ b/hibernate-jpa/src/test/resources/hibernate/custom.hbm.xml
@@ -1,0 +1,6 @@
+<hibernate-mapping xmlns="http://www.hibernate.org/xsd/orm/hbm">
+    <database-object>
+        <definition class="io.micronaut.configuration.hibernate.jpa.mapping.CustomIndexesDatabaseObject"/>
+        <dialect-scope name="org.hibernate.dialect.H2Dialect"/>
+    </database-object>
+</hibernate-mapping>


### PR DESCRIPTION
This feature is equivalent to Spring Boot's feature:

```yaml
spring:
  jpa:
    mapping-resources: hibernate/custom.hbm.xml
```

With these changes, it will enable support for external mapping files with such config:

```yaml
jpa:
  default:
    mapping-resources: hibernate/custom.hbm.xml
```

Can provide a list of resources as well:

```yaml
jpa:
  default:
    mapping-resources: 
    - hibernate/custom1.hbm.xml
    - hibernate/custom2.hbm.xml
```
