### PR TITLE
Updated ucp dependencies.

### DIFF
--- a/jdbc-ucp/build.gradle
+++ b/jdbc-ucp/build.gradle
@@ -5,9 +5,6 @@ dependencies {
     api project(":jdbc")
     api "io.micronaut:micronaut-inject:$micronautVersion"
     api "com.oracle.database.jdbc:ucp:$ojdbcVersion"
-    api("com.oracle.database.jdbc:ojdbc8:$ojdbcVersion") {
-        transitive = false
-    }
 
     testRuntimeOnly "com.h2database:h2"
 
@@ -24,6 +21,7 @@ dependencies {
         exclude module:'groovy-all'
     }
     testImplementation "io.micronaut.test:micronaut-test-spock:$micronautTestVersion"
+    testImplementation "com.oracle.database.jdbc:ojdbc8:$ojdbcVersion"
 }
 
 


### PR DESCRIPTION
UCP requires no additional `api` dependencies.
OJDBC8 moved to test dependencies.