### PR TITLE
Compile-time Hibernate proxies

### DIFF
--- a/.github/workflows/graalvm.yml
+++ b/.github/workflows/graalvm.yml
@@ -1,0 +1,35 @@
+name: GraalVM CE CI
+on:
+  push:
+    branches:
+      - master
+      - '[1-9]+.[0-9]+.x'
+  pull_request:
+    branches:
+      - master
+      - '[1-9]+.[0-9]+.x'
+jobs:
+  build:
+    if: github.repository != 'micronaut-projects/micronaut-project-template'
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        graalvm: ['20.2.0.java8', '20.2.0.java11']
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v2.1.2
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+      - name: Setup GraalVM CE
+        uses: DeLaGuardo/setup-graalvm@2.0
+        with:
+          graalvm-version: ${{ matrix.graalvm }}
+      - name: Install Native Image
+        run: gu install native-image
+      - name: Build with Gradle
+        run: ./gradlew check testNativeImage --continue --no-daemon
+        env:
+          TESTCONTAINERS_RYUK_DISABLED: true

--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,11 @@ buildscript {
 }
 
 subprojects { Project subproject ->
+
+    if (subproject.getPath().startsWith(":test-")) {
+        return
+    }
+
     group "io.micronaut.sql"
     apply plugin: "io.micronaut.build.common"
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,6 @@
 projectVersion=3.2.1.BUILD-SNAPSHOT
 micronautBuildVersion=1.1.5
+micronautGradlePluginVersion=1.1.0
 micronautDocsVersion=1.0.24
 micronautVersion=2.1.1
 micronautTestVersion=2.2.1
@@ -15,6 +16,8 @@ commonsDbcpVersion=2.8.0
 ojdbcVersion=19.8.0.0
 hibernateVersion=5.4.23.Final
 tomcatJdbcVersion=9.0.39
+testContainersVersion=1.15.0-rc2
+jasyncVersion=1.1.4
 
 title=Micronaut SQL Libraries
 projectDesc=Projects to support SQL Database access in Micronaut

--- a/hibernate-jpa/src/main/java/io/micronaut/configuration/hibernate/jpa/graal/HibernateSubstitutions.java
+++ b/hibernate-jpa/src/main/java/io/micronaut/configuration/hibernate/jpa/graal/HibernateSubstitutions.java
@@ -36,6 +36,7 @@ import com.oracle.svm.core.annotate.Substitute;
 import com.oracle.svm.core.annotate.TargetClass;
 
 import io.micronaut.configuration.hibernate.jpa.condition.EntitiesInPackageCondition;
+import io.micronaut.configuration.hibernate.jpa.proxy.IntrospectedHibernateBytecodeProvider;
 import io.micronaut.jdbc.spring.HibernatePresenceCondition;
 import org.hibernate.boot.archive.spi.InputStreamAccess;
 import org.hibernate.boot.jaxb.internal.MappingBinder;
@@ -226,7 +227,7 @@ final class IdOptimizers {
 final class EnvironmentSubs {
     @Substitute
     public static BytecodeProvider buildBytecodeProvider(Properties properties) {
-        return new org.hibernate.bytecode.internal.none.BytecodeProviderImpl();
+        return new IntrospectedHibernateBytecodeProvider();
     }
 }
 

--- a/hibernate-jpa/src/main/java/io/micronaut/configuration/hibernate/jpa/proxy/GenerateProxy.java
+++ b/hibernate-jpa/src/main/java/io/micronaut/configuration/hibernate/jpa/proxy/GenerateProxy.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.configuration.hibernate.jpa.proxy;
+
+import io.micronaut.aop.Around;
+import io.micronaut.aop.Introduction;
+import io.micronaut.context.annotation.Type;
+import jdk.jfr.Experimental;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Annotated Entity class will have a compile time Hibernate proxy.
+ *
+ * @author Denis Stepanov
+ * @since 3.3.0
+ */
+@Around(proxyTarget = true)
+@Introduction(interfaces = IntroducedHibernateProxy.class)
+@Type(IntroducedHibernateProxyAdvice.class)
+@Documented
+@Retention(RUNTIME)
+@Target({ElementType.TYPE})
+@Experimental
+public @interface GenerateProxy {
+}

--- a/hibernate-jpa/src/main/java/io/micronaut/configuration/hibernate/jpa/proxy/IntroducedHibernateProxy.java
+++ b/hibernate-jpa/src/main/java/io/micronaut/configuration/hibernate/jpa/proxy/IntroducedHibernateProxy.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.configuration.hibernate.jpa.proxy;
+
+import io.micronaut.aop.MethodInterceptor;
+import io.micronaut.core.annotation.Internal;
+import org.hibernate.proxy.HibernateProxy;
+
+/**
+ * Introduced {@link HibernateProxy} interface to register an interceptor.
+ *
+ * @author Denis Stepanov
+ * @since 3.3.0
+ */
+@Internal
+public interface IntroducedHibernateProxy extends HibernateProxy {
+
+    @SuppressWarnings("MethodName")
+    void $registerInterceptor(MethodInterceptor<Object, Object> interceptor);
+
+}

--- a/hibernate-jpa/src/main/java/io/micronaut/configuration/hibernate/jpa/proxy/IntroducedHibernateProxyAdvice.java
+++ b/hibernate-jpa/src/main/java/io/micronaut/configuration/hibernate/jpa/proxy/IntroducedHibernateProxyAdvice.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.configuration.hibernate.jpa.proxy;
+
+import io.micronaut.aop.MethodInterceptor;
+import io.micronaut.aop.MethodInvocationContext;
+import io.micronaut.context.annotation.Prototype;
+import io.micronaut.core.annotation.Internal;
+
+/**
+ * Default delegating interceptor for all {@link GenerateProxy} proxies.
+ *
+ * @author Denis Stepanov
+ * @since 3.3.0
+ */
+@Internal
+@Prototype
+public final class IntroducedHibernateProxyAdvice implements MethodInterceptor<Object, Object> {
+
+    private static final String INITIALIZE_PROXY_METHOD = "$registerInterceptor";
+
+    private MethodInterceptor<Object, Object> interceptor;
+
+    @Override
+    public Object intercept(MethodInvocationContext<Object, Object> context) {
+        if (interceptor == null) {
+            if (INITIALIZE_PROXY_METHOD.equals(context.getMethodName())) {
+                interceptor = (MethodInterceptor<Object, Object>) context.getParameterValues()[0];
+                return null;
+            }
+            return context.proceed();
+        }
+        return interceptor.intercept(context);
+    }
+
+}

--- a/hibernate-jpa/src/main/java/io/micronaut/configuration/hibernate/jpa/proxy/IntroducedHibernateProxyFactory.java
+++ b/hibernate-jpa/src/main/java/io/micronaut/configuration/hibernate/jpa/proxy/IntroducedHibernateProxyFactory.java
@@ -82,7 +82,7 @@ final class IntroducedHibernateProxyFactory implements ProxyFactory {
     public HibernateProxy getProxy(Serializable id, SharedSessionContractImplementor session) throws HibernateException {
         if (beanDefinition == null) {
             beanDefinition = beanContext.findProxyTargetBeanDefinition(persistentClass, null)
-                    .orElseThrow(() -> new HibernateException("Cannot find a proxy class, please annotate " + persistentClass + " with @IntroduceHibernateProxy."));
+                    .orElseThrow(() -> new HibernateException("Cannot find a proxy class, please annotate " + persistentClass + " with @GenerateProxy."));
         }
         LazyInitializer lazyInitializer = new IntroducedHibernateProxyLazyInitializer(entityName, persistentClass, id, session);
         Object proxyTargetBean = beanContext.getBean(beanDefinition);

--- a/hibernate-jpa/src/main/java/io/micronaut/configuration/hibernate/jpa/proxy/IntroducedHibernateProxyFactory.java
+++ b/hibernate-jpa/src/main/java/io/micronaut/configuration/hibernate/jpa/proxy/IntroducedHibernateProxyFactory.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.configuration.hibernate.jpa.proxy;
+
+import io.micronaut.context.BeanContext;
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.inject.BeanDefinition;
+import io.micronaut.inject.ExecutableMethod;
+import org.hibernate.HibernateException;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.proxy.HibernateProxy;
+import org.hibernate.proxy.LazyInitializer;
+import org.hibernate.proxy.ProxyFactory;
+import org.hibernate.type.CompositeType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.Serializable;
+import java.lang.reflect.Method;
+import java.util.Collections;
+import java.util.Set;
+
+/**
+ * Implementation of Hibernate's {@link ProxyFactory}.
+ * Compile time proxy will be used if one is added by annotating an entity with {@link GenerateProxy}.
+ *
+ * @author Denis Stepanov
+ * @since 3.3.0
+ */
+@Internal
+final class IntroducedHibernateProxyFactory implements ProxyFactory {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(IntroducedHibernateProxyFactory.class);
+    private static final Set<Class<?>> EXPECTED_INTERFACES = Collections.singleton(HibernateProxy.class);
+    private static final String GET_HIBERNATE_LAZY_INITIALIZER = "getHibernateLazyInitializer";
+
+    private final BeanContext beanContext;
+
+    private String entityName;
+    private Class<?> persistentClass;
+    private CompositeType componentIdType;
+    private Method getIdentifierMethod;
+    private Method setIdentifierMethod;
+
+    private BeanDefinition<?> beanDefinition;
+
+    public IntroducedHibernateProxyFactory(BeanContext beanContext) {
+        this.beanContext = beanContext;
+    }
+
+    @Override
+    public void postInstantiate(String entityName,
+                                Class persistentClass,
+                                Set<Class> interfaces,
+                                Method getIdentifierMethod,
+                                Method setIdentifierMethod,
+                                CompositeType componentIdType) throws HibernateException {
+        this.getIdentifierMethod = getIdentifierMethod;
+        this.setIdentifierMethod = setIdentifierMethod;
+        this.entityName = entityName;
+        this.persistentClass = persistentClass;
+        this.componentIdType = componentIdType;
+        if (LOGGER.isWarnEnabled() && !EXPECTED_INTERFACES.equals(interfaces)) {
+            LOGGER.warn("Expected a single set of 'org.hibernate.proxy.HibernateProxy.class' got {}", interfaces);
+        }
+    }
+
+    @Override
+    public HibernateProxy getProxy(Serializable id, SharedSessionContractImplementor session) throws HibernateException {
+        if (beanDefinition == null) {
+            beanDefinition = beanContext.findProxyTargetBeanDefinition(persistentClass, null)
+                    .orElseThrow(() -> new HibernateException("Cannot find a proxy class, please annotate " + persistentClass + " with @IntroduceHibernateProxy."));
+        }
+        LazyInitializer lazyInitializer = new IntroducedHibernateProxyLazyInitializer(entityName, persistentClass, id, session);
+        Object proxyTargetBean = beanContext.getBean(beanDefinition);
+        IntroducedHibernateProxy introducedHibernateProxy = (IntroducedHibernateProxy) proxyTargetBean;
+        introducedHibernateProxy.$registerInterceptor(context -> {
+            String methodName = context.getMethodName();
+            if ((Class<?>) context.getDeclaringType() == HibernateProxy.class) {
+                if (GET_HIBERNATE_LAZY_INITIALIZER.equals(methodName)) {
+                    return lazyInitializer;
+                }
+                // intercept HibernateProxy#writeReplace
+                throw new HibernateException("InterceptedHibernateProxyFactory doesn't support serializing proxies");
+            }
+
+            // Handle identifier setter / getter
+
+            Object[] parameterValues = context.getParameterValues();
+            int params = parameterValues.length;
+            if (params == 0 && getIdentifierMethod != null && methodName.equals(getIdentifierMethod.getName()) && lazyInitializer.isUninitialized()) {
+                return lazyInitializer.getIdentifier();
+            } else if (params == 1 && setIdentifierMethod != null & methodName.equals(setIdentifierMethod.getName())) {
+                lazyInitializer.initialize();
+                lazyInitializer.setIdentifier((Serializable) parameterValues[0]);
+            }
+
+            // Equals/hashcode should work as other Hibernate proxy implementations:
+            // methods present -> interceptor triggered: initializes proxy and delegate to the target
+            // methods missing -> interceptor not triggered: proxy's methods are invoked
+
+            ExecutableMethod<Object, Object> executableMethod = context.getExecutableMethod();
+            if (componentIdType != null && componentIdType.isMethodOf(executableMethod.getTargetMethod())) {
+                // An entity with multiple @Id's have identifier of the same entity type, an instance only with ids set.
+                return executableMethod.invoke(lazyInitializer.getIdentifier(), parameterValues);
+            }
+            return executableMethod.invoke(lazyInitializer.getImplementation(), parameterValues);
+        });
+        return introducedHibernateProxy;
+    }
+
+}

--- a/hibernate-jpa/src/main/java/io/micronaut/configuration/hibernate/jpa/proxy/IntroducedHibernateProxyFactoryFactory.java
+++ b/hibernate-jpa/src/main/java/io/micronaut/configuration/hibernate/jpa/proxy/IntroducedHibernateProxyFactoryFactory.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.configuration.hibernate.jpa.proxy;
+
+import io.micronaut.context.BeanContext;
+import io.micronaut.core.annotation.Internal;
+import org.hibernate.HibernateException;
+import org.hibernate.bytecode.spi.BasicProxyFactory;
+import org.hibernate.bytecode.spi.ProxyFactoryFactory;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.proxy.ProxyFactory;
+import org.hibernate.resource.beans.spi.ManagedBeanRegistry;
+
+import java.util.Arrays;
+
+/**
+ * Implementation of Hibernate's {@link ProxyFactoryFactory} that creates {@link IntroducedHibernateProxyFactory} with {@link BeanContext}.
+ *
+ * @author Denis Stepanov
+ * @since 3.3.0
+ */
+@Internal
+final class IntroducedHibernateProxyFactoryFactory implements ProxyFactoryFactory {
+
+    @Override
+    public ProxyFactory buildProxyFactory(SessionFactoryImplementor sessionFactory) {
+        BeanContext beanContext = sessionFactory.getServiceRegistry()
+                .getService(ManagedBeanRegistry.class)
+                .getBean(BeanContext.class)
+                .getBeanInstance();
+        return new IntroducedHibernateProxyFactory(beanContext);
+    }
+
+    @Override
+    public BasicProxyFactory buildBasicProxyFactory(Class superClass, Class[] interfaces) {
+        // Fallback?
+        throw new HibernateException("Proxying of basic type " + superClass + " and interfaces " + Arrays.toString(interfaces) + " not supported. Micronaut only supports generating proxies for POJOs and non-basic types. Disable Micronaut compile-time proxies or remove basic type proxy to proceed.");
+    }
+
+}

--- a/hibernate-jpa/src/main/java/io/micronaut/configuration/hibernate/jpa/proxy/IntroducedHibernateProxyLazyInitializer.java
+++ b/hibernate-jpa/src/main/java/io/micronaut/configuration/hibernate/jpa/proxy/IntroducedHibernateProxyLazyInitializer.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.configuration.hibernate.jpa.proxy;
+
+import io.micronaut.core.annotation.Internal;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.proxy.AbstractLazyInitializer;
+
+import java.io.Serializable;
+
+/**
+ * Basic {@link org.hibernate.proxy.LazyInitializer}.
+ *
+ * @author Denis Stepanov
+ * @since 3.3.0
+ */
+@Internal
+final class IntroducedHibernateProxyLazyInitializer extends AbstractLazyInitializer {
+
+    protected final Class<?> persistentClass;
+
+    protected IntroducedHibernateProxyLazyInitializer(String entityName,
+                                                      Class<?> persistentClass,
+                                                      Serializable id,
+                                                      SharedSessionContractImplementor session) {
+        super(entityName, id, session);
+        this.persistentClass = persistentClass;
+    }
+
+    @Override
+    public Class<?> getPersistentClass() {
+        return persistentClass;
+    }
+
+}

--- a/hibernate-jpa/src/main/java/io/micronaut/configuration/hibernate/jpa/proxy/IntrospectedHibernateBytecodeProvider.java
+++ b/hibernate-jpa/src/main/java/io/micronaut/configuration/hibernate/jpa/proxy/IntrospectedHibernateBytecodeProvider.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.configuration.hibernate.jpa.proxy;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.beans.BeanIntrospection;
+import io.micronaut.core.beans.BeanIntrospector;
+import io.micronaut.core.beans.BeanProperty;
+import org.hibernate.bytecode.enhance.spi.EnhancementContext;
+import org.hibernate.bytecode.enhance.spi.Enhancer;
+import org.hibernate.bytecode.spi.BytecodeProvider;
+import org.hibernate.bytecode.spi.ProxyFactoryFactory;
+import org.hibernate.bytecode.spi.ReflectionOptimizer;
+
+import javax.inject.Singleton;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Compile-time proxies implementation of Hibernate's {@link BytecodeProvider}.
+ * Implementation provides custom implementation of {@link ProxyFactoryFactory} and disables bytecode enhancer.
+ *
+ * @author Denis Stepanov
+ * @since 3.3.0
+ */
+@Singleton
+@Internal
+public final class IntrospectedHibernateBytecodeProvider implements BytecodeProvider {
+
+    private static final Enhancer NO_OP = (className, originalBytes) -> null;
+
+    @Override
+    public ProxyFactoryFactory getProxyFactoryFactory() {
+        return new IntroducedHibernateProxyFactoryFactory();
+    }
+
+    @Override
+    public ReflectionOptimizer getReflectionOptimizer(Class clazz, String[] getterNames, String[] setterNames, Class[] types) {
+        Optional<BeanIntrospection<?>> optionalBeanIntrospection = BeanIntrospector.SHARED.findIntrospection(clazz);
+        if (!optionalBeanIntrospection.isPresent()) {
+            return null;
+        }
+        BeanIntrospection<?> beanIntrospection = optionalBeanIntrospection.get();
+        return new ReflectionOptimizer() {
+            @Override
+            public InstantiationOptimizer getInstantiationOptimizer() {
+                return beanIntrospection::instantiate;
+            }
+
+            @Override
+            public AccessOptimizer getAccessOptimizer() {
+                List<BeanProperty> beanProperties = new ArrayList<>(beanIntrospection.getBeanProperties());
+                return new AccessOptimizer() {
+
+                    @Override
+                    public String[] getPropertyNames() {
+                        return beanProperties
+                                .stream()
+                                .map(BeanProperty::getName)
+                                .toArray(String[]::new);
+                    }
+
+                    @Override
+                    public Object[] getPropertyValues(Object object) {
+                        return beanProperties
+                                .stream()
+                                .map(prop -> prop.get(object))
+                                .toArray(Object[]::new);
+                    }
+
+                    @Override
+                    public void setPropertyValues(Object object, Object[] values) {
+                        for (int i = 0; i < beanProperties.size(); i++) {
+                            beanProperties.get(i).set(object, values[i]);
+                        }
+                    }
+                };
+            }
+        };
+    }
+
+    @Override
+    public Enhancer getEnhancer(EnhancementContext enhancementContext) {
+        return NO_OP;
+    }
+
+}

--- a/hibernate-jpa/src/test/groovy/io/micronaut/configuration/hibernate/jpa/proxy/CustomId.java
+++ b/hibernate-jpa/src/test/groovy/io/micronaut/configuration/hibernate/jpa/proxy/CustomId.java
@@ -1,0 +1,33 @@
+package io.micronaut.configuration.hibernate.jpa.proxy;
+
+import java.io.Serializable;
+
+public class CustomId implements Serializable {
+
+    private String a;
+    private String b;
+
+    public CustomId() {
+    }
+
+    public CustomId(String a, String b) {
+        this.a = a;
+        this.b = b;
+    }
+
+    public String getA() {
+        return a;
+    }
+
+    public void setA(String a) {
+        this.a = a;
+    }
+
+    public String getB() {
+        return b;
+    }
+
+    public void setB(String b) {
+        this.b = b;
+    }
+}

--- a/hibernate-jpa/src/test/groovy/io/micronaut/configuration/hibernate/jpa/proxy/Customer.java
+++ b/hibernate-jpa/src/test/groovy/io/micronaut/configuration/hibernate/jpa/proxy/Customer.java
@@ -1,0 +1,62 @@
+package io.micronaut.configuration.hibernate.jpa.proxy;
+
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.ManyToOne;
+
+@Entity
+public class Customer {
+
+    @Id
+    @GeneratedValue
+    private Long id;
+    private String name;
+    @ManyToOne(fetch = FetchType.LAZY)
+    private DepartmentCompositeId departmentCompositeId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    private DepartmentSimpleWithEquals departmentSimpleWithEquals;
+    @ManyToOne(fetch = FetchType.LAZY)
+    private DepartmentSimpleWithoutEquals departmentSimpleWithoutEquals;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public DepartmentCompositeId getDepartmentCompositeId() {
+        return departmentCompositeId;
+    }
+
+    public void setDepartmentCompositeId(DepartmentCompositeId departmentCompositeId) {
+        this.departmentCompositeId = departmentCompositeId;
+    }
+
+    public DepartmentSimpleWithEquals getDepartmentSimpleWithEquals() {
+        return departmentSimpleWithEquals;
+    }
+
+    public void setDepartmentSimpleWithEquals(DepartmentSimpleWithEquals departmentSimpleWithEquals) {
+        this.departmentSimpleWithEquals = departmentSimpleWithEquals;
+    }
+
+    public DepartmentSimpleWithoutEquals getDepartmentSimpleWithoutEquals() {
+        return departmentSimpleWithoutEquals;
+    }
+
+    public void setDepartmentSimpleWithoutEquals(DepartmentSimpleWithoutEquals departmentSimpleWithoutEquals) {
+        this.departmentSimpleWithoutEquals = departmentSimpleWithoutEquals;
+    }
+}

--- a/hibernate-jpa/src/test/groovy/io/micronaut/configuration/hibernate/jpa/proxy/DepartmentCompositeId.java
+++ b/hibernate-jpa/src/test/groovy/io/micronaut/configuration/hibernate/jpa/proxy/DepartmentCompositeId.java
@@ -1,0 +1,55 @@
+package io.micronaut.configuration.hibernate.jpa.proxy;
+
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.Id;
+import javax.persistence.OneToMany;
+import java.io.Serializable;
+import java.util.Set;
+
+@Entity
+@GenerateProxy
+public class DepartmentCompositeId implements Serializable {
+
+    @Id
+    private String a;
+    @Id
+    private String b;
+    private String name;
+
+    @OneToMany(fetch = FetchType.LAZY, mappedBy = "departmentCompositeId")
+    private Set<Customer> customers;
+
+    public String getA() {
+        return a;
+    }
+
+    public void setA(String a) {
+        this.a = a;
+    }
+
+    public String getB() {
+        return b;
+    }
+
+    public void setB(String b) {
+        this.b = b;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Set<Customer> getCustomers() {
+        return customers;
+    }
+
+    public void setCustomers(Set<Customer> customers) {
+        this.customers = customers;
+    }
+
+}

--- a/hibernate-jpa/src/test/groovy/io/micronaut/configuration/hibernate/jpa/proxy/DepartmentSimpleWithEquals.java
+++ b/hibernate-jpa/src/test/groovy/io/micronaut/configuration/hibernate/jpa/proxy/DepartmentSimpleWithEquals.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.configuration.hibernate.jpa.proxy;
+
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.OneToMany;
+import java.io.Serializable;
+import java.util.Objects;
+import java.util.Set;
+
+@Entity
+@GenerateProxy
+public class DepartmentSimpleWithEquals implements Serializable {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private Long id;
+    private String name;
+
+    @OneToMany(fetch = FetchType.LAZY, mappedBy = "departmentSimpleWithEquals")
+    private Set<Customer> customers;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Set<Customer> getCustomers() {
+        return customers;
+    }
+
+    public void setCustomers(Set<Customer> customers) {
+        this.customers = customers;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof DepartmentSimpleWithEquals)) return false;
+        DepartmentSimpleWithEquals that = (DepartmentSimpleWithEquals) o;
+        return Objects.equals(id, that.getId());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+}

--- a/hibernate-jpa/src/test/groovy/io/micronaut/configuration/hibernate/jpa/proxy/DepartmentSimpleWithoutEquals.java
+++ b/hibernate-jpa/src/test/groovy/io/micronaut/configuration/hibernate/jpa/proxy/DepartmentSimpleWithoutEquals.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.configuration.hibernate.jpa.proxy;
+
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.OneToMany;
+import java.io.Serializable;
+import java.util.Set;
+
+@Entity
+@GenerateProxy
+public class DepartmentSimpleWithoutEquals implements Serializable {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private Long id;
+    private String name;
+
+    @OneToMany(fetch = FetchType.LAZY, mappedBy = "departmentSimpleWithoutEquals")
+    private Set<Customer> customers;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Set<Customer> getCustomers() {
+        return customers;
+    }
+
+    public void setCustomers(Set<Customer> customers) {
+        this.customers = customers;
+    }
+
+}

--- a/hibernate-jpa/src/test/groovy/io/micronaut/configuration/hibernate/jpa/proxy/EmbeddedData.java
+++ b/hibernate-jpa/src/test/groovy/io/micronaut/configuration/hibernate/jpa/proxy/EmbeddedData.java
@@ -1,0 +1,17 @@
+package io.micronaut.configuration.hibernate.jpa.proxy;
+
+import javax.persistence.Embeddable;
+
+@Embeddable
+public class EmbeddedData {
+
+    private String f;
+
+    public String getF() {
+        return f;
+    }
+
+    public void setF(String f) {
+        this.f = f;
+    }
+}

--- a/hibernate-jpa/src/test/groovy/io/micronaut/configuration/hibernate/jpa/proxy/IntroduceHibernateProxySpec.groovy
+++ b/hibernate-jpa/src/test/groovy/io/micronaut/configuration/hibernate/jpa/proxy/IntroduceHibernateProxySpec.groovy
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.configuration.hibernate.jpa.proxy
+
+import io.micronaut.aop.Introduced
+import io.micronaut.context.ApplicationContext
+import org.hibernate.proxy.HibernateProxy
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+import spock.lang.Specification
+
+import javax.persistence.EntityManager
+import javax.persistence.EntityManagerFactory
+
+class IntroduceHibernateProxySpec extends Specification {
+
+    @Shared
+    @AutoCleanup
+    ApplicationContext applicationContext = ApplicationContext.run(
+            'datasources.default.name': 'mydb',
+            'jpa.default.properties.hibernate.hbm2ddl.auto': 'create-drop',
+            'jpa.default.compile-time-hibernate-proxies': true
+    )
+
+    void "test customer with simple lazy with equals"() {
+        when:
+            EntityManagerFactory entityManagerFactory = applicationContext.getBean(EntityManagerFactory)
+
+        then:
+            entityManagerFactory != null
+
+        when:
+            EntityManager em = entityManagerFactory.createEntityManager()
+            def tx = em.getTransaction()
+            tx.begin()
+            def newDepartment = new DepartmentSimpleWithEquals(name: "Xyz")
+            em.persist(newDepartment)
+            def newCustomer = new Customer(name: "Joe")
+            newCustomer.setDepartmentSimpleWithEquals(newDepartment)
+            em.persist(newCustomer)
+            em.flush()
+            em.clear()
+
+        then:
+            def customer = em.find(Customer, newCustomer.getId())
+            def department = customer.getDepartmentSimpleWithEquals()
+            department instanceof Introduced
+            department instanceof HibernateProxy
+            department instanceof IntroducedHibernateProxy
+            def lazyInitializer = ((HibernateProxy) department).getHibernateLazyInitializer()
+            lazyInitializer.isUninitialized()
+            department.getId() // call to identifier method shouldn't init proxy
+            department.getId() == newDepartment.getId()
+            lazyInitializer.isUninitialized()
+            // hash code or equals are implemented -> should trigger lazy init
+            department.hashCode() == department.hashCode() // Init proxy
+            !lazyInitializer.isUninitialized()
+            department.hashCode() == newDepartment.hashCode()
+            department.equals(department)
+            department.equals(newDepartment)
+            newDepartment.equals(department)
+            !department.equals(new DepartmentSimpleWithEquals(id: 123L))
+            !new DepartmentSimpleWithEquals(id: 123L).equals(department)
+            department.getName()
+            department.getName() == newDepartment.getName()
+
+        cleanup:
+            tx.rollback()
+    }
+
+    void "test customer with simple lazy without equals"() {
+        when:
+            EntityManagerFactory entityManagerFactory = applicationContext.getBean(EntityManagerFactory)
+
+        then:
+            entityManagerFactory != null
+
+        when:
+            EntityManager em = entityManagerFactory.createEntityManager()
+            def tx = em.getTransaction()
+            tx.begin()
+            def newDepartment = new DepartmentSimpleWithoutEquals(name: "Xyz")
+            em.persist(newDepartment)
+            def newCustomer = new Customer(name: "Joe")
+            newCustomer.setDepartmentSimpleWithoutEquals(newDepartment)
+            em.persist(newCustomer)
+            em.flush()
+            em.clear()
+
+        then:
+            def customer = em.find(Customer, newCustomer.getId())
+            def department = customer.getDepartmentSimpleWithoutEquals()
+            department instanceof Introduced
+            department instanceof HibernateProxy
+            department instanceof IntroducedHibernateProxy
+            def lazyInitializer = ((HibernateProxy) department).getHibernateLazyInitializer()
+            lazyInitializer.isUninitialized()
+            department.getId() // call to identifier method shouldn't init proxy
+            department.getId() == newDepartment.getId()
+            department.hashCode() != newDepartment.hashCode()
+            department.equals(department) // proxy equals proxy
+            !department.equals(newDepartment) // proxy not equals no-proxy
+            lazyInitializer.isUninitialized()
+            // hashCode or equals aren't implemented -> shouldn't match and shouldn't trigger lazy init
+            department.getName() // Init proxy
+            !lazyInitializer.isUninitialized()
+            department.getName() == newDepartment.getName()
+
+        cleanup:
+            tx.rollback()
+    }
+
+    // test for componentIdType.isMethodOf(executableMethod.getTargetMethod())
+    void "test customer with composite id"() {
+        when:
+            EntityManagerFactory entityManagerFactory = applicationContext.getBean(EntityManagerFactory)
+
+        then:
+            entityManagerFactory != null
+
+        when:
+            EntityManager em = entityManagerFactory.createEntityManager()
+            def tx = em.getTransaction()
+            tx.begin()
+            def departmentComposite = new DepartmentCompositeId(a: "xx", b: "yy", name: "Xyz")
+            em.persist(departmentComposite)
+            def newCustomer = new Customer(name: "Joe")
+            newCustomer.setDepartmentCompositeId(departmentComposite)
+            em.persist(newCustomer)
+            em.flush()
+            em.clear()
+
+        then:
+            def customer = em.find(Customer, newCustomer.getId())
+            def depComposite = customer.getDepartmentCompositeId()
+            depComposite instanceof Introduced
+            depComposite instanceof HibernateProxy
+            depComposite instanceof IntroducedHibernateProxy
+            def lazyInitializer = ((HibernateProxy) depComposite).getHibernateLazyInitializer()
+            lazyInitializer.isUninitialized()
+            depComposite.getA() // call to identifier method shouldn't init proxy
+            depComposite.getB() // call to identifier method shouldn't init proxy
+            depComposite.getA() == departmentComposite.getA()
+            depComposite.getB() == departmentComposite.getB()
+            depComposite.hashCode() // hashcode of the proxy
+            depComposite.equals(depComposite) // equals of the proxy
+            !depComposite.equals(departmentComposite)
+            lazyInitializer.isUninitialized()
+            // hashCode or equals aren't implemented -> shouldn't match and shouldn't trigger lazy init
+            depComposite.getName()
+            !lazyInitializer.isUninitialized()
+            depComposite.getName() == departmentComposite.getName()
+        cleanup:
+            tx.rollback()
+    }
+}
+
+

--- a/jasync-sql/build.gradle
+++ b/jasync-sql/build.gradle
@@ -1,7 +1,3 @@
-ext {
-    testContainersVersion="1.15.0-rc2"
-    jasyncVersion="1.1.4"
-}
 dependencies {
     annotationProcessor "io.micronaut:micronaut-inject-java"
     annotationProcessor "io.micronaut.docs:micronaut-docs-asciidoc-config-props:$micronautDocsVersion"

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,10 @@
+pluginManagement {
+    plugins {
+        id 'io.micronaut.application' version getProperty("micronautGradlePluginVersion")
+        id 'io.micronaut.library' version getProperty("micronautGradlePluginVersion")
+    }
+}
+
 rootProject.name = 'sql'
 
 include 'jdbc'
@@ -12,4 +19,12 @@ include 'jooq'
 include 'vertx-mysql-client'
 include 'vertx-pg-client'
 include 'jdbi'
-
+include 'test-graalvm-hibernate-jpa'
+include 'test-graalvm-hibernate-jpa:postgres'
+include 'test-graalvm-hibernate-jpa:mysql'
+include 'test-graalvm-hibernate-jpa:mariadb'
+include 'test-graalvm-hibernate-jpa:oracle'
+include 'test-graalvm-hibernate-jpa:h2'
+include 'test-graalvm-hibernate-jpa:mssql'
+include 'test-graalvm-hibernate-jpa:common'
+include 'test-graalvm-hibernate-jpa:common-tests'

--- a/src/main/docs/guide/hibernate.adoc
+++ b/src/main/docs/guide/hibernate.adoc
@@ -130,6 +130,53 @@ Note that this approach has the following disadvantages:
 * It is slower, since Micronaut has to search through JAR files and scan class files with ASM
 * It does not work in GraalVM substrate.
 
+==== Using compile-time Hibernate proxies
+
+Hibernate uses a proxy object to implement lazy loading with a default implementation generating a proxy during the runtime.
+
+This has a few disadvantages:
+
+* Runtime class generation can affect startup and runtime performance
+* Environments like GraalVM don't support it
+
+If you wish to use lazy entity associations and avoid runtime proxies you can enable compile-time proxies:
+[source,yaml]
+----
+jpa:
+  default:
+    compile-time-hibernate-proxies: true
+----
+
+Compile-time proxies require for an entity which needs to have a proxy to be annotated with `@GenerateProxy`:
+
+For example:
+
+[source,java]
+----
+@Entity
+public class Pet {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Owner owner;
+
+    //...
+}
+----
+
+The entity `Owner` needs to be annotated with `@GenerateProxy` to have a proxy generated and the compile-time.
+
+[source,java]
+----
+@Entity
+@GenerateProxy
+public class Owner {
+    //...
+}
+----
+
+[NOTE]
+Compile-time proxies are enabled by default for GraalVM environment.
+
 
 ==== Using Spring Transaction Management
 

--- a/test-graalvm-hibernate-jpa/build.gradle
+++ b/test-graalvm-hibernate-jpa/build.gradle
@@ -1,0 +1,135 @@
+plugins {
+    id 'io.micronaut.application' apply false
+    id 'io.micronaut.library' apply false
+}
+
+subprojects { Project subproject ->
+
+    apply plugin: "java"
+    apply plugin: "groovy"
+
+    group "io.micronaut.example"
+
+    repositories {
+        jcenter()
+        mavenCentral()
+    }
+
+    sourceCompatibility = 1.8
+    targetCompatibility = 1.8
+
+    configurations {
+        all*.exclude module: "byte-buddy"
+        all*.exclude module: "javassist"
+    }
+
+    if (subproject.getName().startsWith("common")) {
+        apply plugin: 'io.micronaut.library'
+
+        micronaut {
+            version project.ext.micronautVersion
+        }
+
+        return
+    }
+
+    apply plugin: 'io.micronaut.application'
+
+    micronaut {
+        version project.ext.micronautVersion
+        runtime "netty"
+        testRuntime "spock"
+    }
+
+    dependencies {
+        runtimeOnly "io.micronaut.sql:micronaut-jdbc-hikari"
+        runtimeOnly "ch.qos.logback:logback-classic"
+
+        implementation "io.micronaut:micronaut-http-client"
+        implementation project(":test-graalvm-hibernate-jpa:common")
+        testImplementation project(":test-graalvm-hibernate-jpa:common-tests")
+
+        testImplementation "io.micronaut.test:micronaut-test-core:$micronautTestVersion"
+        testImplementation platform("org.testcontainers:testcontainers-bom:$testContainersVersion")
+        testImplementation "org.testcontainers:spock"
+        testImplementation "org.testcontainers:jdbc"
+    }
+
+    nativeImage {
+        args("-H:+TraceClassInitialization")
+    }
+
+    mainClassName = "example.Application"
+}
+
+project("common") {
+    dependencies {
+        implementation "io.micronaut:micronaut-http-client"
+        annotationProcessor "io.micronaut:micronaut-graal"
+        implementation project(":hibernate-jpa")
+    }
+}
+project("common-tests") {
+    dependencies {
+        implementation "io.micronaut:micronaut-http-client"
+        implementation "io.micronaut.test:micronaut-test-core:$micronautTestVersion"
+        implementation platform("org.testcontainers:testcontainers-bom:$testContainersVersion")
+        implementation "org.testcontainers:spock"
+        implementation "org.testcontainers:jdbc"
+    }
+}
+project("h2") {
+    dependencies {
+        runtimeOnly "com.h2database:h2"
+    }
+    nativeImage {
+        args("--report-unsupported-elements-at-runtime")
+    }
+    // Skip on GraalVM Java11
+    tasks.findByName("testNativeImage").onlyIf { !isGraal() || JavaVersion.current() != JavaVersion.VERSION_11 }
+    tasks.findByName("nativeImage").onlyIf { !isGraal() || JavaVersion.current() != JavaVersion.VERSION_11 }
+}
+project("mssql") {
+    dependencies {
+        runtimeOnly "com.microsoft.sqlserver:mssql-jdbc"
+        testImplementation "org.testcontainers:mssqlserver"
+    }
+    nativeImage {
+        args("--report-unsupported-elements-at-runtime")
+        args("-H:+AddAllCharsets")
+    }
+}
+project("postgres") {
+    dependencies {
+        runtimeOnly "org.postgresql:postgresql"
+        testImplementation "org.testcontainers:postgresql"
+    }
+}
+project("oracle") {
+    dependencies {
+        runtimeOnly "com.oracle.ojdbc:ojdbc8"
+        testImplementation "org.testcontainers:oracle-xe"
+    }
+}
+project("mysql") {
+    dependencies {
+        runtimeOnly "mysql:mysql-connector-java"
+        testImplementation "org.testcontainers:mysql"
+    }
+}
+project("mariadb") {
+    dependencies {
+        runtimeOnly "org.mariadb.jdbc:mariadb-java-client"
+        testImplementation "org.testcontainers:mariadb"
+    }
+}
+
+boolean isGraal() {
+    for (String prop : ["jvmci.Compiler", "java.vendor.version"]) {
+        String vv = System.getProperty(prop)
+        if (vv != null && vv.toLowerCase(Locale.ENGLISH).contains("graal")) {
+            return true
+        }
+    }
+    return false
+}

--- a/test-graalvm-hibernate-jpa/common-tests/src/main/groovy/example/controllers/AbstractAppSpec.groovy
+++ b/test-graalvm-hibernate-jpa/common-tests/src/main/groovy/example/controllers/AbstractAppSpec.groovy
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.controllers
+
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.client.RxHttpClient
+import io.micronaut.http.client.annotation.Client
+import spock.lang.Specification
+import spock.lang.Stepwise
+
+import javax.inject.Inject
+
+@Stepwise
+abstract class AbstractAppSpec extends Specification {
+
+    @Inject
+    @Client("/")
+    RxHttpClient client
+
+    def 'should init'() {
+        when:
+            client.exchange(HttpRequest.GET("/init")).blockingFirst()
+        then:
+            noExceptionThrown()
+    }
+
+    def 'should fetch owners'() {
+        when:
+            def results = client.retrieve(HttpRequest.GET("/owners"), List).blockingFirst()
+        then:
+            results.size() == 2
+            results[0].name == "Fred"
+            results[1].name == "Barney"
+    }
+
+    def 'should fetch owner by name'() {
+        when:
+            def result = client.retrieve(HttpRequest.GET("/owners/Fred"), Map).blockingFirst()
+        then:
+            result.name == "Fred"
+    }
+
+    def 'should fetch pets'() {
+        when:
+            def results = client.retrieve(HttpRequest.GET("/pets"), List).blockingFirst()
+        then:
+            results.size() == 3
+            results[0].name == "Dino"
+            results[0].owner.name == "Fred"
+            results[1].name == "Baby Puss"
+            results[1].owner.name == "Fred"
+            results[2].name == "Hoppy"
+            results[2].owner.name == "Barney"
+    }
+
+    def 'should fetch pet by name'() {
+        when:
+            def result = client.retrieve(HttpRequest.GET("/pets/Dino"), Map).blockingFirst()
+        then:
+            result.name == "Dino"
+            result.owner.name == "Fred"
+    }
+
+}

--- a/test-graalvm-hibernate-jpa/common-tests/src/main/groovy/example/controllers/AbstractDBContainerAppSpec.groovy
+++ b/test-graalvm-hibernate-jpa/common-tests/src/main/groovy/example/controllers/AbstractDBContainerAppSpec.groovy
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.controllers
+
+import io.micronaut.test.support.TestPropertyProvider
+import org.testcontainers.containers.JdbcDatabaseContainer
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+
+abstract class AbstractDBContainerAppSpec extends AbstractAppSpec implements TestPropertyProvider {
+
+    @Shared
+    @AutoCleanup
+    JdbcDatabaseContainer dbContainer = getJdbcDatabaseContainer()
+
+    @Override
+    Map<String, String> getProperties() {
+        dbContainer.start()
+        return [
+                "datasources.default.url"                 : dbContainer.getJdbcUrl(),
+                "jpa.default.properties.hibernate.dialect": getHibernateDialect(),
+                "datasources.default.driverClassName"     : dbContainer.getDriverClassName(),
+                "datasources.default.username"            : dbContainer.getUsername(),
+                "datasources.default.password"            : dbContainer.getPassword(),
+        ]
+    }
+
+    abstract JdbcDatabaseContainer getJdbcDatabaseContainer();
+
+    abstract String getHibernateDialect();
+
+}

--- a/test-graalvm-hibernate-jpa/common/src/main/java/example/Application.java
+++ b/test-graalvm-hibernate-jpa/common/src/main/java/example/Application.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example;
+
+import io.micronaut.runtime.Micronaut;
+
+public class Application {
+
+    public static void main(String[] args) {
+        Micronaut.run(Application.class);
+    }
+}

--- a/test-graalvm-hibernate-jpa/common/src/main/java/example/controllers/InitController.java
+++ b/test-graalvm-hibernate-jpa/common/src/main/java/example/controllers/InitController.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.controllers;
+
+import example.domain.Owner;
+import example.domain.Pet;
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Get;
+import io.micronaut.transaction.annotation.TransactionalAdvice;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.persistence.EntityManager;
+
+@Controller("/init")
+class InitController {
+    private static final Logger LOG = LoggerFactory.getLogger(InitController.class);
+
+    private final EntityManager entityManager;
+
+    public InitController(EntityManager entityManager) {
+        this.entityManager = entityManager;
+    }
+
+    @Get
+    @TransactionalAdvice
+    void init() {
+        try {
+            Class.forName("net.bytebuddy.ByteBuddy");
+            throw new IllegalStateException("ByteBuddy shouldn't be present on classpath");
+        } catch (ClassNotFoundException e) {
+            // Ignore
+        }
+        try {
+            Class.forName("javassist.util.proxy.ProxyFactory");
+            throw new IllegalStateException("Javassist shouldn't be present on classpath");
+        } catch (ClassNotFoundException e) {
+            // Ignore
+        }
+        if (LOG.isInfoEnabled()) {
+            LOG.info("Running on " + System.getProperty("java.version") + " " + System.getProperty("java.vendor.version"));
+            LOG.info("Populating data");
+        }
+
+        Owner fred = new Owner();
+        fred.setName("Fred");
+        fred.setAge(45);
+        Owner barney = new Owner();
+        barney.setName("Barney");
+        barney.setAge(40);
+
+        entityManager.persist(fred);
+        entityManager.persist(barney);
+
+        Pet dino = new Pet();
+        dino.setName("Dino");
+        dino.setOwner(fred);
+        Pet bp = new Pet();
+        bp.setName("Baby Puss");
+        bp.setOwner(fred);
+        bp.setType(Pet.PetType.CAT);
+        Pet hoppy = new Pet();
+        hoppy.setName("Hoppy");
+        hoppy.setOwner(barney);
+
+        entityManager.persist(dino);
+        entityManager.persist(bp);
+        entityManager.persist(hoppy);
+    }
+
+}

--- a/test-graalvm-hibernate-jpa/common/src/main/java/example/controllers/Mapper.java
+++ b/test-graalvm-hibernate-jpa/common/src/main/java/example/controllers/Mapper.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.controllers;
+
+import example.controllers.dto.OwnerDto;
+import example.controllers.dto.PetDto;
+import example.domain.Owner;
+import example.domain.Pet;
+
+import javax.inject.Singleton;
+
+@Singleton
+public class Mapper {
+
+    public PetDto toPetDto(Pet pet) {
+        PetDto petDto = new PetDto();
+        petDto.setId(pet.getId());
+        petDto.setName(pet.getName());
+        petDto.setType(pet.getType());
+        petDto.setOwner(toOwnerDto(pet.getOwner()));
+        return petDto;
+    }
+
+    public OwnerDto toOwnerDto(Owner owner) {
+        OwnerDto ownerDto = new OwnerDto();
+        ownerDto.setAge(owner.getAge());
+        ownerDto.setId(owner.getId());
+        ownerDto.setName(owner.getName());
+        return ownerDto;
+    }
+
+}

--- a/test-graalvm-hibernate-jpa/common/src/main/java/example/controllers/OwnerController.java
+++ b/test-graalvm-hibernate-jpa/common/src/main/java/example/controllers/OwnerController.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.controllers;
+
+import example.controllers.dto.OwnerDto;
+import example.domain.Owner;
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Get;
+import io.micronaut.transaction.annotation.TransactionalAdvice;
+
+import javax.persistence.EntityManager;
+import javax.validation.constraints.NotBlank;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Controller("/owners")
+class OwnerController {
+
+    private final EntityManager entityManager;
+    private final Mapper mapper;
+
+    OwnerController(EntityManager entityManager, Mapper mapper) {
+        this.entityManager = entityManager;
+        this.mapper = mapper;
+    }
+
+    @Get
+    @TransactionalAdvice(readOnly = true)
+    List<OwnerDto> all() {
+        return entityManager.createQuery("from Owner", Owner.class)
+                .getResultList()
+                .stream()
+                .map(mapper::toOwnerDto)
+                .collect(Collectors.toList());
+    }
+
+    @Get("/{name}")
+    @TransactionalAdvice(readOnly = true)
+    Optional<OwnerDto> byName(@NotBlank String name) {
+        return entityManager.createQuery("from Owner where name = :name", Owner.class)
+                .setParameter("name", name)
+                .getResultList()
+                .stream()
+                .findFirst()
+                .map(mapper::toOwnerDto);
+    }
+
+}

--- a/test-graalvm-hibernate-jpa/common/src/main/java/example/controllers/PetController.java
+++ b/test-graalvm-hibernate-jpa/common/src/main/java/example/controllers/PetController.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.controllers;
+
+import example.controllers.dto.PetDto;
+import example.domain.Pet;
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Get;
+import io.micronaut.transaction.annotation.TransactionalAdvice;
+import org.hibernate.Hibernate;
+
+import javax.persistence.EntityManager;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Controller("/pets")
+class PetController {
+
+    private final EntityManager entityManager;
+    private final Mapper mapper;
+
+    PetController(EntityManager entityManager, Mapper mapper) {
+        this.entityManager = entityManager;
+        this.mapper = mapper;
+    }
+
+    @TransactionalAdvice(readOnly = true)
+    @Get
+    List<PetDto> all() {
+        List<Pet> from_pet = entityManager.createQuery("from Pet", Pet.class)
+                .getResultList();
+        return from_pet
+                .stream()
+                .map(mapper::toPetDto)
+                .collect(Collectors.toList());
+    }
+
+    @TransactionalAdvice(readOnly = true)
+    @Get("/{name}")
+    Optional<PetDto> byName(String name) {
+        return entityManager.createQuery("from Pet where name = :name", Pet.class)
+                .setParameter("name", name)
+                .getResultList()
+                .stream()
+                .findFirst()
+                .map(pet -> {
+                    if (Hibernate.isInitialized(pet.getOwner())) {
+                        throw new IllegalStateException("Expected not initialized owner ref");
+                    }
+                    PetDto petDto = mapper.toPetDto(pet);
+                    if (!Hibernate.isInitialized(pet.getOwner())) {
+                        throw new IllegalStateException("Expected initialized owner ref");
+                    }
+                    return petDto;
+                });
+    }
+
+}

--- a/test-graalvm-hibernate-jpa/common/src/main/java/example/controllers/dto/OwnerDto.java
+++ b/test-graalvm-hibernate-jpa/common/src/main/java/example/controllers/dto/OwnerDto.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.controllers.dto;
+
+import io.micronaut.core.annotation.Introspected;
+
+@Introspected
+public class OwnerDto {
+
+    private Long id;
+    private String name;
+    private int age;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public int getAge() {
+        return age;
+    }
+
+    public void setAge(int age) {
+        this.age = age;
+    }
+}

--- a/test-graalvm-hibernate-jpa/common/src/main/java/example/controllers/dto/PetDto.java
+++ b/test-graalvm-hibernate-jpa/common/src/main/java/example/controllers/dto/PetDto.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.controllers.dto;
+
+import example.domain.Pet;
+import io.micronaut.core.annotation.Introspected;
+
+@Introspected
+public class  PetDto {
+
+    private Long id;
+    private String name;
+    private OwnerDto owner;
+    private Pet.PetType type;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public OwnerDto getOwner() {
+        return owner;
+    }
+
+    public void setOwner(OwnerDto owner) {
+        this.owner = owner;
+    }
+
+    public Pet.PetType getType() {
+        return type;
+    }
+
+    public void setType(Pet.PetType type) {
+        this.type = type;
+    }
+}

--- a/test-graalvm-hibernate-jpa/common/src/main/java/example/domain/Owner.java
+++ b/test-graalvm-hibernate-jpa/common/src/main/java/example/domain/Owner.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.domain;
+
+import io.micronaut.configuration.hibernate.jpa.proxy.GenerateProxy;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+
+@Entity
+@GenerateProxy
+public class Owner {
+
+    @Id
+    @GeneratedValue
+    private Long id;
+    private String name;
+    private int age;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public int getAge() {
+        return age;
+    }
+
+    public void setAge(int age) {
+        this.age = age;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    @Override
+    public String toString() {
+        return "Owner{" +
+                "id=" + id +
+                ", name='" + name + '\'' +
+                ", age=" + age +
+                '}';
+    }
+}

--- a/test-graalvm-hibernate-jpa/common/src/main/java/example/domain/Pet.java
+++ b/test-graalvm-hibernate-jpa/common/src/main/java/example/domain/Pet.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.domain;
+
+import io.micronaut.core.annotation.Introspected;
+
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.ManyToOne;
+
+@Entity
+public class Pet {
+
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    private String name;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Owner owner;
+
+    private PetType type = PetType.DOG;
+
+    public PetType getType() {
+        return type;
+    }
+
+    public Owner getOwner() {
+        return owner;
+    }
+
+    public void setOwner(Owner owner) {
+        this.owner = owner;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public void setType(PetType type) {
+        this.type = type;
+    }
+
+    @Introspected
+    public enum PetType {
+        DOG,
+        CAT
+    }
+
+    @Override
+    public String toString() {
+        return "Pet{" +
+                "id=" + id +
+                ", name='" + name + '\'' +
+                ", owner=" + owner +
+                ", type=" + type +
+                '}';
+    }
+}

--- a/test-graalvm-hibernate-jpa/common/src/main/resources/application.yml
+++ b/test-graalvm-hibernate-jpa/common/src/main/resources/application.yml
@@ -1,0 +1,16 @@
+micronaut:
+  application:
+    name: graalvm-hibernate-jpa
+  http:
+    client:
+      read-timeout: 60s
+jackson:
+  bean-introspection-module: true
+jpa:
+  default:
+    compile-time-hibernate-proxies: true
+    properties:
+      hibernate:
+        hbm2ddl:
+          auto: update
+        show_sql: true

--- a/test-graalvm-hibernate-jpa/common/src/main/resources/logback.xml
+++ b/test-graalvm-hibernate-jpa/common/src/main/resources/logback.xml
@@ -1,0 +1,14 @@
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <withJansi>true</withJansi>
+        <encoder>
+            <pattern>%cyan(%d{HH:mm:ss.SSS}) %gray([%thread]) %highlight(%-5level) %magenta(%logger{36}) - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="info">
+        <appender-ref ref="STDOUT" />
+    </root>
+
+</configuration>

--- a/test-graalvm-hibernate-jpa/h2/src/test/groovy/example/controllers/H2AppSpec.groovy
+++ b/test-graalvm-hibernate-jpa/h2/src/test/groovy/example/controllers/H2AppSpec.groovy
@@ -1,0 +1,36 @@
+
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.controllers
+
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import io.micronaut.test.support.TestPropertyProvider
+
+@MicronautTest
+class H2AppSpec extends AbstractAppSpec implements TestPropertyProvider {
+
+    @Override
+    Map<String, String> getProperties() {
+        return [
+                "jpa.default.properties.hibernate.dialect": "org.hibernate.dialect.H2Dialect",
+                "datasources.default.url"                 : "jdbc:h2:mem:devDb;MVCC=TRUE;LOCK_TIMEOUT=10000;DB_CLOSE_ON_EXIT=FALSE",
+                "datasources.default.driverClassName"     : "org.h2.Driver",
+                "datasources.default.username"            : "sa",
+                "datasources.default.password"            : ""
+        ]
+    }
+
+}

--- a/test-graalvm-hibernate-jpa/mariadb/src/test/groovy/example/controllers/MariaDBAppSpec.groovy
+++ b/test-graalvm-hibernate-jpa/mariadb/src/test/groovy/example/controllers/MariaDBAppSpec.groovy
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.controllers
+
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import org.testcontainers.containers.JdbcDatabaseContainer
+import org.testcontainers.containers.MariaDBContainer
+import org.testcontainers.utility.DockerImageName
+
+@MicronautTest
+class MariaDBAppSpec extends AbstractDBContainerAppSpec {
+
+    @Override
+    JdbcDatabaseContainer getJdbcDatabaseContainer() {
+        return new MariaDBContainer(DockerImageName.parse("mariadb:10.3.6"))
+    }
+
+    @Override
+    String getHibernateDialect() {
+        return "org.hibernate.dialect.MariaDB103Dialect"
+    }
+}

--- a/test-graalvm-hibernate-jpa/mssql/src/test/groovy/example/controllers/MSSQLAppSpec.groovy
+++ b/test-graalvm-hibernate-jpa/mssql/src/test/groovy/example/controllers/MSSQLAppSpec.groovy
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.controllers
+
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import io.micronaut.test.support.TestPropertyProvider
+import org.testcontainers.containers.JdbcDatabaseContainer
+import org.testcontainers.containers.MSSQLServerContainer
+
+@MicronautTest
+class MSSQLAppSpec extends AbstractDBContainerAppSpec implements TestPropertyProvider {
+
+    @Override
+    JdbcDatabaseContainer getJdbcDatabaseContainer() {
+        return new MSSQLServerContainer().acceptLicense()
+    }
+
+    @Override
+    String getHibernateDialect() {
+        return "org.hibernate.dialect.SQLServer2012Dialect"
+    }
+}

--- a/test-graalvm-hibernate-jpa/mysql/src/test/groovy/example/controllers/MySQLAppSpec.groovy
+++ b/test-graalvm-hibernate-jpa/mysql/src/test/groovy/example/controllers/MySQLAppSpec.groovy
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.controllers
+
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import io.micronaut.test.support.TestPropertyProvider
+import org.testcontainers.containers.JdbcDatabaseContainer
+import org.testcontainers.containers.MySQLContainer
+import org.testcontainers.utility.DockerImageName
+
+@MicronautTest
+class MySQLAppSpec extends AbstractDBContainerAppSpec implements TestPropertyProvider {
+
+    @Override
+    JdbcDatabaseContainer getJdbcDatabaseContainer() {
+        return new MySQLContainer(DockerImageName.parse("mysql:8.0.11"))
+    }
+
+    @Override
+    String getHibernateDialect() {
+        return "org.hibernate.dialect.MySQL8Dialect"
+    }
+}

--- a/test-graalvm-hibernate-jpa/oracle/src/test/groovy/example/controllers/OracleDBAppSpec.groovy
+++ b/test-graalvm-hibernate-jpa/oracle/src/test/groovy/example/controllers/OracleDBAppSpec.groovy
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.controllers
+
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import org.testcontainers.containers.JdbcDatabaseContainer
+import org.testcontainers.containers.OracleContainer
+import org.testcontainers.utility.DockerImageName
+
+@MicronautTest
+class OracleDBAppSpec extends AbstractDBContainerAppSpec {
+
+    @Override
+    JdbcDatabaseContainer getJdbcDatabaseContainer() {
+        return new OracleContainer(DockerImageName.parse("registry.gitlab.com/micronaut-projects/micronaut-graal-tests/oracle-database:18.4.0-xe"))
+    }
+
+    @Override
+    String getHibernateDialect() {
+        return "org.hibernate.dialect.Oracle10gDialect"
+    }
+
+}

--- a/test-graalvm-hibernate-jpa/postgres/src/test/groovy/example/controllers/PostgresAppSpec.groovy
+++ b/test-graalvm-hibernate-jpa/postgres/src/test/groovy/example/controllers/PostgresAppSpec.groovy
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.controllers
+
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import org.testcontainers.containers.JdbcDatabaseContainer
+import org.testcontainers.containers.PostgreSQLContainer
+import org.testcontainers.utility.DockerImageName
+
+@MicronautTest
+class PostgresAppSpec extends AbstractDBContainerAppSpec {
+
+    @Override
+    JdbcDatabaseContainer getJdbcDatabaseContainer() {
+        return new PostgreSQLContainer(DockerImageName.parse("postgres:9.6.12"))
+    }
+
+    @Override
+    String getHibernateDialect() {
+        return "org.hibernate.dialect.PostgreSQL95Dialect"
+    }
+
+}


### PR DESCRIPTION
The implementation uses Micronaut's AOP to generate a proxy during the compile-time.
Benefits should be:
- performance
- startup time because it looks like bytebuddy is generating some enhancements for all the classes
- Proxies can be used in GraalVM 