### PR TITLE
Add ability to configure jOOQ ConverterProvider 

### DIFF
--- a/jooq/build.gradle
+++ b/jooq/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     compileOnly "org.springframework:spring-jdbc:$springVersion"
     compileOnly "io.micronaut.data:micronaut-data-tx:$micronautDataVersion"
     compileOnly "org.simpleflatmapper:sfm-reflect:8.2.3"
+    compileOnly "com.fasterxml.jackson.core:jackson-databind"
 
     testRuntimeOnly project(":jdbc-tomcat")
     testRuntimeOnly "com.h2database:h2:1.4.200"

--- a/jooq/src/main/java/io/micronaut/configuration/jooq/JacksonConverterProvider.java
+++ b/jooq/src/main/java/io/micronaut/configuration/jooq/JacksonConverterProvider.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.configuration.jooq;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import io.micronaut.context.annotation.Requires;
+import org.jooq.Converter;
+import org.jooq.ConverterProvider;
+import org.jooq.JSON;
+import org.jooq.JSONB;
+import org.jooq.exception.DataTypeException;
+import org.jooq.impl.DefaultConverterProvider;
+
+import javax.inject.Singleton;
+
+/**
+ * jOOQ ConverterProvider integrating Jackson ObjectMapper to convert JSON and JSONB types.
+ *
+ * @author Lukas Moravec
+ * @since 3.2.1
+ */
+@Singleton
+@Requires(beans = {ObjectMapper.class})
+public class JacksonConverterProvider implements ConverterProvider {
+
+    private final ConverterProvider delegate = new DefaultConverterProvider();
+    private final ObjectMapper objectMapper;
+
+    public JacksonConverterProvider(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    @Nullable
+    @SuppressWarnings("unchecked")
+    public <T, U> Converter<T, U> provide(Class<T> tType, Class<U> uType) {
+        if (tType == JSON.class) {
+            return Converter.ofNullable(tType, uType,
+                    t -> {
+                        try {
+                            return objectMapper.readValue(((JSON) t).data(), uType);
+                        } catch (Exception e) {
+                            throw new DataTypeException("JSON mapping error", e);
+                        }
+                    },
+                    u -> {
+                        try {
+                            return (T) JSON.valueOf(objectMapper.writeValueAsString(u));
+                        } catch (Exception e) {
+                            throw new DataTypeException("JSON mapping error", e);
+                        }
+                    }
+            );
+        } else if (tType == JSONB.class) {
+            return Converter.ofNullable(tType, uType,
+                    t -> {
+                        try {
+                            return objectMapper.readValue(((JSONB) t).data(), uType);
+                        } catch (Exception e) {
+                            throw new DataTypeException("JSON mapping error", e);
+                        }
+                    },
+                    u -> {
+                        try {
+                            return (T) JSONB.valueOf(objectMapper.writeValueAsString(u));
+                        } catch (Exception e) {
+                            throw new DataTypeException("JSON mapping error", e);
+                        }
+                    }
+            );
+        } else {
+            return delegate.provide(tType, uType);
+        }
+    }
+}

--- a/jooq/src/main/java/io/micronaut/configuration/jooq/JooqConfigurationFactory.java
+++ b/jooq/src/main/java/io/micronaut/configuration/jooq/JooqConfigurationFactory.java
@@ -50,6 +50,7 @@ public class JooqConfigurationFactory {
      * @param recordMapperProvider   The record mapper provider
      * @param recordUnmapperProvider The record unmapper provider
      * @param metaProvider           The metadata provider
+     * @param converterProvider      The converter provider
      * @param ctx                    The {@link ApplicationContext}
      * @return A {@link Configuration}
      */
@@ -63,6 +64,7 @@ public class JooqConfigurationFactory {
             @Parameter @Nullable RecordMapperProvider recordMapperProvider,
             @Parameter @Nullable RecordUnmapperProvider recordUnmapperProvider,
             @Parameter @Nullable MetaProvider metaProvider,
+            @Parameter @Nullable ConverterProvider converterProvider,
             ApplicationContext ctx
     ) {
         DefaultConfiguration configuration = new DefaultConfiguration();
@@ -90,6 +92,11 @@ public class JooqConfigurationFactory {
         }
         if (metaProvider != null) {
             configuration.setMetaProvider(metaProvider);
+        }
+        if (converterProvider != null) {
+            configuration.set(converterProvider);
+        } else if (properties.isJacksonConverterEnabled()) {
+            ctx.findBean(JacksonConverterProvider.class).ifPresent(configuration::set);
         }
         configuration.setExecuteListenerProvider(ctx.getBeansOfType(ExecuteListenerProvider.class, Qualifiers.byName(name))
                 .toArray(new ExecuteListenerProvider[0]));

--- a/jooq/src/main/java/io/micronaut/configuration/jooq/JooqConfigurationProperties.java
+++ b/jooq/src/main/java/io/micronaut/configuration/jooq/JooqConfigurationProperties.java
@@ -33,6 +33,7 @@ import java.sql.SQLException;
 public class JooqConfigurationProperties {
 
     private SQLDialect sqlDialect;
+    private boolean jacksonConverterEnabled = false;
 
     /**
      * SQL dialect to use. If {@code null}, will be detected automatically.
@@ -50,6 +51,24 @@ public class JooqConfigurationProperties {
      */
     public void setSqlDialect(SQLDialect sqlDialect) {
         this.sqlDialect = sqlDialect;
+    }
+
+    /**
+     * If enable {@link JacksonConverterProvider} bean to use Jackson for JSON and JSONB types.
+     *
+     * @return boolean
+     */
+    public boolean isJacksonConverterEnabled() {
+        return jacksonConverterEnabled;
+    }
+
+    /**
+     * Set if enable {@link JacksonConverterProvider} bean to use Jackson for JSON and JSONB types.
+     *
+     * @param jacksonConverterEnabled Enable Jackson
+     */
+    public void setJacksonConverterEnabled(boolean jacksonConverterEnabled) {
+        this.jacksonConverterEnabled = jacksonConverterEnabled;
     }
 
     /**

--- a/jooq/src/test/groovy/io/micronaut/configuration/jooq/ConverterProviderSpec.groovy
+++ b/jooq/src/test/groovy/io/micronaut/configuration/jooq/ConverterProviderSpec.groovy
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.configuration.jooq
+
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.DefaultApplicationContext
+import io.micronaut.context.env.MapPropertySource
+import io.micronaut.inject.qualifiers.Qualifiers
+import org.jooq.ConverterProvider
+import org.jooq.DSLContext
+import org.jooq.impl.DefaultConverterProvider
+import spock.lang.Specification
+
+class ConverterProviderSpec extends Specification {
+
+    void "test no configuration"() {
+        given:
+        ApplicationContext applicationContext = new DefaultApplicationContext("test")
+        applicationContext.environment.addPropertySource(MapPropertySource.of(
+                'test',
+                ['datasources.default': [:]]
+        ))
+        applicationContext.start()
+
+        expect:
+        applicationContext.getBean(DSLContext).configuration().converterProvider() instanceof DefaultConverterProvider
+
+        cleanup:
+        applicationContext.close()
+    }
+
+    void "test custom converter provider"() {
+        given:
+        ApplicationContext applicationContext = new DefaultApplicationContext("test")
+        applicationContext.environment.addPropertySource(MapPropertySource.of(
+                'test',
+                ['datasources.default': [:]]
+        ))
+        applicationContext.registerSingleton(ConverterProvider, new CustomConverterProvider(), Qualifiers.byName("default"))
+        applicationContext.start()
+
+        expect:
+        applicationContext.getBean(DSLContext).configuration().converterProvider() instanceof CustomConverterProvider
+
+        cleanup:
+        applicationContext.close()
+    }
+
+    void "test built-in jackson converter provider"() {
+        given:
+        ApplicationContext applicationContext = new DefaultApplicationContext("test")
+        applicationContext.environment.addPropertySource(MapPropertySource.of(
+                'test',
+                ['datasources.default'     : [:],
+                 'jooq.datasources.default.jackson-converter-enabled': true]
+        ))
+        applicationContext.start()
+
+        expect:
+        applicationContext.getBean(DSLContext).configuration().converterProvider() instanceof JacksonConverterProvider
+
+        cleanup:
+        applicationContext.close()
+    }
+
+}

--- a/jooq/src/test/groovy/io/micronaut/configuration/jooq/CustomConverterProvider.java
+++ b/jooq/src/test/groovy/io/micronaut/configuration/jooq/CustomConverterProvider.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.configuration.jooq;
+
+import org.jetbrains.annotations.Nullable;
+import org.jooq.Converter;
+import org.jooq.ConverterProvider;
+import org.jooq.impl.DefaultConverterProvider;
+
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+public class CustomConverterProvider implements ConverterProvider {
+
+    private final DefaultConverterProvider delegate = new DefaultConverterProvider();
+
+    @Override
+    public @Nullable <T, U> Converter<T, U> provide(Class<T> tType, Class<U> uType) {
+        return delegate.provide(tType, uType);
+    }
+
+}

--- a/jooq/src/test/groovy/io/micronaut/configuration/jooq/JacksonConverterSpec.groovy
+++ b/jooq/src/test/groovy/io/micronaut/configuration/jooq/JacksonConverterSpec.groovy
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.configuration.jooq
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.DefaultApplicationContext
+import io.micronaut.context.env.MapPropertySource
+import org.jooq.Converter
+import org.jooq.ConverterProvider
+import org.jooq.JSON
+import org.jooq.JSONB
+import spock.lang.Specification
+
+class JacksonConverterSpec extends Specification {
+
+    void "test json conversion"() {
+        given:
+        ApplicationContext applicationContext = new DefaultApplicationContext("test")
+        applicationContext.environment.addPropertySource(MapPropertySource.of(
+                'test',
+                ['datasources.default'                               : [:],
+                 'jooq.datasources.default.jackson-converter-enabled': true]
+        ))
+        applicationContext.start()
+
+        ConverterProvider converterProvider = applicationContext.getBean(ConverterProvider)
+
+        expect:
+        converterProvider instanceof JacksonConverterProvider
+
+        when:
+        Converter jsonConverter = converterProvider.provide(JSON, TestObject)
+        Converter jsonbConverter = converterProvider.provide(JSONB, TestObject)
+        String serialized = "{\"name\":\"Test\",\"count\":3}"
+        TestObject object = new TestObject("Test", 3)
+
+        then:
+        jsonConverter != null
+        jsonbConverter != null
+
+        jsonConverter.from(JSON.valueOf(serialized)) == object
+        jsonbConverter.from(JSONB.valueOf(serialized)) == object
+
+        jsonConverter.to(object) == JSON.valueOf(serialized)
+        jsonbConverter.to(object) == JSONB.valueOf(serialized)
+
+        cleanup:
+        applicationContext.close()
+    }
+
+}

--- a/jooq/src/test/groovy/io/micronaut/configuration/jooq/TestObject.java
+++ b/jooq/src/test/groovy/io/micronaut/configuration/jooq/TestObject.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.configuration.jooq;
+
+import io.micronaut.core.annotation.Introspected;
+
+import java.util.Objects;
+
+@Introspected
+public class TestObject {
+
+    private final String name;
+    private final Integer count;
+
+    public TestObject(String name, Integer count) {
+        this.name = name;
+        this.count = count;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public Integer getCount() {
+        return count;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        TestObject that = (TestObject) o;
+        return name.equals(that.name) && count.equals(that.count);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, count);
+    }
+
+}

--- a/src/main/docs/guide/jooq.adoc
+++ b/src/main/docs/guide/jooq.adoc
@@ -45,11 +45,25 @@ Micronaut will look for the following bean types:
 * link:{jooqapi}/org/jooq/RecordMapperProvider.html[RecordMapperProvider]
 * link:{jooqapi}/org/jooq/RecordUnmapperProvider.html[RecordUnmapperProvider]
 * link:{jooqapi}/org/jooq/MetaProvider.html[MetaProvider]
+* link:{jooqapi}/org/jooq/ConverterProvider.html[ConverterProvider]
 * link:{jooqapi}/org/jooq/ExecuteListenerProvider.html[ExecuteListenerProvider]
 * link:{jooqapi}/org/jooq/RecordListenerProvider.html[RecordListenerProvider]
 * link:{jooqapi}/org/jooq/VisitListenerProvider.html[VisitListenerProvider]
 * link:{jooqapi}/org/jooq/TransactionListenerProvider.html[TransactionListenerProvider]
 * link:{jooqapi}/org/jooq/DiagnosticsListenerProvider.html[DiagnosticsListenerProvider]
+
+=== Using Micronaut's ObjectMapper to convert JSON(B) types ===
+
+If you don't register bean of type link:{jooqapi}/org/jooq/ConverterProvider.html[ConverterProvider] and provide following configuration, `JacksonConverterProvider` will be used, which uses Micronaut configured `ObjectMapper` for converting from and to types JSON and JSONB.
+
+.Configuring Micronaut Jackson converter
+[source,yaml]
+----
+jooq:
+    datasources:
+        default:
+            jackson-converter-enabled: true
+----
 
 === GraalVM native image ===
 


### PR DESCRIPTION
and create default implementation using builtin Jackson for JSON and JSONB types (must me configured)

https://www.jooq.org/doc/3.14/manual/sql-execution/fetching/converter-provider/