### PR TITLE
Register jOOQ data type classes for reflection

### DIFF
--- a/jooq/src/main/java/io/micronaut/configuration/jooq/graal/DefaultDataTypeReflection.java
+++ b/jooq/src/main/java/io/micronaut/configuration/jooq/graal/DefaultDataTypeReflection.java
@@ -54,6 +54,16 @@ import io.micronaut.core.annotation.TypeHint.AccessType;
                 "org.jooq.JSONB[]",
                 "java.util.UUID[]",
                 "byte[]",
+                "org.jooq.impl.SQLDataType",
+                "org.jooq.util.cubrid.CUBRIDDataType",
+                "org.jooq.util.derby.DerbyDataType",
+                "org.jooq.util.firebird.FirebirdDataType",
+                "org.jooq.util.h2.H2DataType",
+                "org.jooq.util.hsqldb.HSQLDBDataType",
+                "org.jooq.util.mariadb.MariaDBDataType",
+                "org.jooq.util.mysql.MySQLDataType",
+                "org.jooq.util.postgres.PostgresDataType",
+                "org.jooq.util.sqlite.SQLiteDataType",
         },
         accessType = AccessType.ALL_PUBLIC_CONSTRUCTORS
 )


### PR DESCRIPTION
Without it, everything compiles fine, but in runtime, the default dialect is used (e.g. casting to CLOB instead of TEXT in Postgres).
