### PR TITLE
Allow to replace hibernate current session class

### DIFF
--- a/hibernate-jpa-spring/build.gradle
+++ b/hibernate-jpa-spring/build.gradle
@@ -10,6 +10,8 @@ dependencies {
     }
 
     api "io.micronaut:micronaut-aop:$micronautVersion"
+    api project(":hibernate-jpa")
+
     api project(":jdbc")
     api "io.micronaut.spring:micronaut-spring"
     api "org.springframework:spring-orm:$springVersion"

--- a/hibernate-jpa-spring/src/main/java/io/micronaut/configuration/hibernate/jpa/spring/SpringHibernateCurrentSessionContextClassProvider.java
+++ b/hibernate-jpa-spring/src/main/java/io/micronaut/configuration/hibernate/jpa/spring/SpringHibernateCurrentSessionContextClassProvider.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.configuration.hibernate.jpa.spring;
+
+import io.micronaut.configuration.hibernate.jpa.HibernateCurrentSessionContextClassProvider;
+import org.hibernate.context.spi.CurrentSessionContext;
+import org.springframework.orm.hibernate5.SpringSessionContext;
+
+import javax.inject.Singleton;
+
+/**
+ * Spring integration implementation of {@link HibernateCurrentSessionContextClassProvider}.
+ *
+ * @author Denis Stepanov
+ * @since 3.3.2
+ */
+@Singleton
+public class SpringHibernateCurrentSessionContextClassProvider implements HibernateCurrentSessionContextClassProvider {
+
+    /**
+     * @return SpringSessionContext
+     */
+    @Override
+    public Class<? extends CurrentSessionContext> get() {
+        return SpringSessionContext.class;
+    }
+
+}

--- a/hibernate-jpa/src/main/java/io/micronaut/configuration/hibernate/jpa/EntityManagerFactoryBean.java
+++ b/hibernate-jpa/src/main/java/io/micronaut/configuration/hibernate/jpa/EntityManagerFactoryBean.java
@@ -16,6 +16,7 @@
 package io.micronaut.configuration.hibernate.jpa;
 
 
+import io.micronaut.transaction.hibernate5.MicronautSessionContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -23,10 +24,8 @@ import io.micronaut.configuration.hibernate.jpa.condition.RequiresHibernateEntit
 import io.micronaut.context.BeanLocator;
 import io.micronaut.context.annotation.*;
 import io.micronaut.context.env.Environment;
-import io.micronaut.core.reflect.ClassUtils;
 import io.micronaut.inject.qualifiers.Qualifiers;
 import io.micronaut.jdbc.DataSourceResolver;
-import io.micronaut.transaction.hibernate5.MicronautSessionContext;
 import org.hibernate.Interceptor;
 import org.hibernate.MappingException;
 import org.hibernate.SessionFactory;
@@ -107,11 +106,9 @@ public class EntityManagerFactoryBean {
 
         Map<String, Object> additionalSettings = new LinkedHashMap<>();
         additionalSettings.put(AvailableSettings.DATASOURCE, dataSource);
-        Class<?> sessionContextClass = ClassUtils.forName("org.springframework.orm.hibernate5"
-                                                        + ".SpringSessionContext", EntityManagerFactoryBean.class.getClassLoader())
-                .orElse(MicronautSessionContext.class);
-        additionalSettings.put(
-                AvailableSettings.CURRENT_SESSION_CONTEXT_CLASS, sessionContextClass.getName());
+        additionalSettings.put(AvailableSettings.CURRENT_SESSION_CONTEXT_CLASS,
+                beanLocator.findBean(HibernateCurrentSessionContextClassProvider.class)
+                        .map(provider -> provider.get().getName()).orElseGet(MicronautSessionContext.class::getName));
         additionalSettings.put(AvailableSettings.SESSION_FACTORY_NAME, dataSourceName);
         additionalSettings.put(AvailableSettings.SESSION_FACTORY_NAME_IS_JNDI, false);
         additionalSettings.put(AvailableSettings.BEAN_CONTAINER, new BeanContainer() {

--- a/hibernate-jpa/src/main/java/io/micronaut/configuration/hibernate/jpa/HibernateCurrentSessionContextClassProvider.java
+++ b/hibernate-jpa/src/main/java/io/micronaut/configuration/hibernate/jpa/HibernateCurrentSessionContextClassProvider.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.configuration.hibernate.jpa;
+
+import org.hibernate.context.spi.CurrentSessionContext;
+
+/**
+ * Provides the value for {@link org.hibernate.cfg.AvailableSettings#CURRENT_SESSION_CONTEXT_CLASS}.
+ *
+ * @author Denis Stepanov
+ * @since 3.3.2
+ */
+public interface HibernateCurrentSessionContextClassProvider {
+
+    /**
+     * @return the class implementing {@link CurrentSessionContext}
+     */
+    Class<? extends CurrentSessionContext> get();
+
+}


### PR DESCRIPTION
Followup https://github.com/micronaut-projects/micronaut-sql/issues/372
This should remove the need to have `DataEntityManagerFactoryBean`.