### PR TITLE
Native-image configuration for the MySQL X protocol.

### DIFF
--- a/jdbc/src/main/java/io/micronaut/jdbc/nativeimage/JdbcFeature.java
+++ b/jdbc/src/main/java/io/micronaut/jdbc/nativeimage/JdbcFeature.java
@@ -297,6 +297,10 @@ final class JdbcFeature implements Feature {
 
             registerAllForRuntimeReflection(access, "com.mysql.cj.log.StandardLogger");
             registerAllForRuntimeReflection(access, "com.mysql.cj.conf.url.SingleConnectionUrl");
+            // Required for X protocol
+            registerAllForRuntimeReflection(access, "com.mysql.cj.conf.url.XDevApiConnectionUrl");
+            registerAllForRuntimeReflection(access, "com.mysql.cj.protocol.x.SyncFlushDeflaterOutputStream");
+            registerAllForRuntimeReflection(access, "java.util.zip.InflaterInputStream");
 
             registerFieldsAndMethodsWithReflectiveAccess(access, "com.mysql.cj.protocol.StandardSocketFactory");
             registerFieldsAndMethodsWithReflectiveAccess(access, "com.mysql.cj.jdbc.AbandonedConnectionCleanupThread");


### PR DESCRIPTION
This PR closes https://github.com/micronaut-projects/micronaut-sql/issues/398.

Some classes required by the MySQL driver for the X protocol weren't registered for reflection.