### PR TITLE
Swap out JPA for Jakarta Persistence

### DIFF
--- a/src/main/docs/guide/hibernate.adoc
+++ b/src/main/docs/guide/hibernate.adoc
@@ -29,7 +29,7 @@ You can use the `javax.persistence.PersistenceContext` annotation to inject an `
 [source,groovy]
 .Adding the JPA dependency to `annotationProcessor` in Gradle
 ----
-annotationProcessor "javax.persistence:javax.persistence-api:2.2"
+annotationProcessor "jakarta.persistence:jakarta.persistence-api:2.2"
 ----
 
 [source,java]


### PR DESCRIPTION
According to the [Micronaut Data docs](https://micronaut-projects.github.io/micronaut-data/latest/guide/), `jakarta.persistence:jakarta.persistence-api` should be used.

It stands to reason that if the Jakarta API works with the lower-level Micronaut SQL, it _probably_ works with Micronaut Data.

Of course, I could be wrong(!), but a PR is a great way to start a conversation about it.