### PR TITLE
Don't allow closing a transactional session.

### DIFF
--- a/hibernate-jpa/src/main/java/io/micronaut/configuration/hibernate/jpa/TransactionalSessionInterceptor.java
+++ b/hibernate-jpa/src/main/java/io/micronaut/configuration/hibernate/jpa/TransactionalSessionInterceptor.java
@@ -53,6 +53,11 @@ class TransactionalSessionInterceptor implements MethodInterceptor<Session, Obje
     @Override
     public Object intercept(MethodInvocationContext<Session, Object> context) {
         final ExecutableMethod<Session, Object> method = context.getExecutableMethod();
-        return method.invoke(sessionFactory.getCurrentSession(), context.getParameterValues());
+        if (method.getName().equals("close") && method.getArguments().length == 0) {
+            // close handled by transaction management, ignore
+            return null;
+        } else {
+            return method.invoke(sessionFactory.getCurrentSession(), context.getParameterValues());
+        }
     }
 }

--- a/hibernate-jpa/src/test/groovy/io/micronaut/configuration/hibernate/jpa/JavaBookService.java
+++ b/hibernate-jpa/src/test/groovy/io/micronaut/configuration/hibernate/jpa/JavaBookService.java
@@ -60,4 +60,10 @@ public class JavaBookService {
         ((AutoCloseable)entityManager).close();
         return true;
     }
+
+    public boolean testCloseWithoutTx() throws Exception {
+        // just testing the method can be invoked
+        ((AutoCloseable)entityManager).close();
+        return true;
+    }
 }

--- a/hibernate-jpa/src/test/groovy/io/micronaut/configuration/hibernate/jpa/JpaSetupSpec.groovy
+++ b/hibernate-jpa/src/test/groovy/io/micronaut/configuration/hibernate/jpa/JpaSetupSpec.groovy
@@ -135,6 +135,8 @@ class JpaSetupSpec extends Specification {
         bookService.testMethodInject()
         bookService.testNativeQuery()
         readOnlyBookService.testNativeQuery()
+        bookService.testClose()
+        bookService.testCloseWithoutTx()
     }
 }
 


### PR DESCRIPTION
This is causing a problem with Micronaut 3.x.

In general a transactional session should always be closed by transaction management so we should make the "close" method a no-op.

This is consistent with the way TransactionalConnection works in JDBC:

https://github.com/micronaut-projects/micronaut-data/blob/a49aa61a1c49659ba62b5dd1bfeb18cbb0232941/data-tx/src/main/java/io/micronaut/transaction/jdbc/TransactionalConnectionInterceptor.java#L69