### PR TITLE
Add IgniteDataType to reflection configuration

### DIFF
--- a/jooq/src/main/java/io/micronaut/configuration/jooq/graal/DefaultDataTypeReflection.java
+++ b/jooq/src/main/java/io/micronaut/configuration/jooq/graal/DefaultDataTypeReflection.java
@@ -60,6 +60,7 @@ import io.micronaut.core.annotation.TypeHint.AccessType;
                 "org.jooq.util.firebird.FirebirdDataType",
                 "org.jooq.util.h2.H2DataType",
                 "org.jooq.util.hsqldb.HSQLDBDataType",
+                "org.jooq.util.ignite.IgniteDataType",
                 "org.jooq.util.mariadb.MariaDBDataType",
                 "org.jooq.util.mysql.MySQLDataType",
                 "org.jooq.util.postgres.PostgresDataType",


### PR DESCRIPTION
In jOOQ 3.15 Ignite support was added and without this configuration, it is not possible to use types INSTANT types.