### PR TITLE
fix: start ucp pool by using listener

### DIFF
--- a/jdbc-ucp/src/main/java/io/micronaut/configuration/jdbc/ucp/ConnectionPoolManagerListener.java
+++ b/jdbc-ucp/src/main/java/io/micronaut/configuration/jdbc/ucp/ConnectionPoolManagerListener.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2017-2021 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.configuration.jdbc.ucp;
+
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.context.event.BeanCreatedEvent;
+import io.micronaut.context.event.BeanCreatedEventListener;
+import io.micronaut.context.exceptions.ConfigurationException;
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.order.Ordered;
+import jakarta.inject.Singleton;
+import oracle.ucp.UniversalConnectionPoolAdapter;
+import oracle.ucp.UniversalConnectionPoolException;
+import oracle.ucp.admin.UniversalConnectionPoolManager;
+import oracle.ucp.admin.UniversalConnectionPoolManagerImpl;
+import oracle.ucp.jdbc.PoolDataSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.sql.DataSource;
+
+
+/**
+ * {@link BeanCreatedEventListener} that starts the {@link PoolDataSource} using the {@link UniversalConnectionPoolManager}.
+ *
+ * @author Pavol Gressa
+ * @since 4.0.3
+ */
+@Singleton
+@Requires(classes = PoolDataSource.class)
+@Internal
+public class ConnectionPoolManagerListener implements BeanCreatedEventListener<DataSource>, Ordered {
+    private static final int POSITION = Ordered.LOWEST_PRECEDENCE;
+    private static final Logger LOG = LoggerFactory.getLogger(ConnectionPoolManagerListener.class);
+
+    @Override
+    public DataSource onCreated(BeanCreatedEvent<DataSource> event) {
+        final DataSource dataSource = event.getBean();
+        if (dataSource instanceof PoolDataSource) {
+            final PoolDataSource poolDataSource = (PoolDataSource) dataSource;
+            final String poolName = poolDataSource.getConnectionPoolName();
+            try {
+                final UniversalConnectionPoolManager connectionPoolManager = UniversalConnectionPoolManagerImpl.getUniversalConnectionPoolManager();
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("Creating connection pool named: {}", poolName);
+                }
+                connectionPoolManager.createConnectionPool((UniversalConnectionPoolAdapter) dataSource);
+
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("Starting connection pool named: {}", poolName);
+                }
+                connectionPoolManager.startConnectionPool(poolName);
+                if (LOG.isInfoEnabled()) {
+                    LOG.info("Connection pool named: {} started", poolName);
+                }
+
+            } catch (UniversalConnectionPoolException e) {
+                throw new ConfigurationException(String.format("Failed to start connection pool named: %s", poolName), e);
+            }
+        }
+        return event.getBean();
+    }
+
+    @Override
+    public int getOrder() {
+        return POSITION;
+    }
+}

--- a/jdbc-ucp/src/main/java/io/micronaut/configuration/jdbc/ucp/DatasourceConfiguration.java
+++ b/jdbc-ucp/src/main/java/io/micronaut/configuration/jdbc/ucp/DatasourceConfiguration.java
@@ -64,6 +64,7 @@ public class DatasourceConfiguration implements BasicJdbcConfiguration {
     public DatasourceConfiguration(@Parameter String name) throws SQLException {
         super();
         this.name = name;
+        this.delegate.setConnectionPoolName(name);
         this.calculatedSettings = new CalculatedSettings(this);
     }
 

--- a/jdbc-ucp/src/main/java/io/micronaut/configuration/jdbc/ucp/DatasourceFactory.java
+++ b/jdbc-ucp/src/main/java/io/micronaut/configuration/jdbc/ucp/DatasourceFactory.java
@@ -19,7 +19,6 @@ import io.micronaut.context.ApplicationContext;
 import io.micronaut.context.annotation.Context;
 import io.micronaut.context.annotation.EachBean;
 import io.micronaut.context.annotation.Factory;
-import oracle.ucp.UniversalConnectionPoolAdapter;
 import oracle.ucp.UniversalConnectionPoolException;
 import oracle.ucp.admin.UniversalConnectionPoolManager;
 import oracle.ucp.admin.UniversalConnectionPoolManagerImpl;
@@ -32,7 +31,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Creates a ucp data source for each configuration bean.
+ * Creates an ucp data source for each configuration bean.
  *
  * @author toddsharp
  * @since 2.0.1
@@ -66,8 +65,6 @@ public class DatasourceFactory implements AutoCloseable {
         PoolDataSource ds = datasourceConfiguration.delegate;
         dataSources.add(ds);
 
-        connectionPoolManager.createConnectionPool((UniversalConnectionPoolAdapter) ds);
-        connectionPoolManager.startConnectionPool(ds.getConnectionPoolName());
         return ds;
     }
 
@@ -79,7 +76,7 @@ public class DatasourceFactory implements AutoCloseable {
                 if (LOG.isDebugEnabled()) {
                     LOG.debug("Closing connection pool named: {}", dataSource.getConnectionPoolName());
                 }
-                UniversalConnectionPoolManagerImpl.getUniversalConnectionPoolManager().destroyConnectionPool(dataSource.getConnectionPoolName());
+                connectionPoolManager.destroyConnectionPool(dataSource.getConnectionPoolName());
             } catch (Exception e) {
                 if (LOG.isWarnEnabled()) {
                     LOG.warn("Error closing data source [" + dataSource + "]: " + e.getMessage(), e);


### PR DESCRIPTION
The bean listener is ordered so there's a room to let the other listeners to tweak the configuration, like the oraclecloud-atp module does.