### PR TITLE
Use jdbi3-bom platform instead of jdbi-core

### DIFF
--- a/sql-bom/build.gradle
+++ b/sql-bom/build.gradle
@@ -9,8 +9,6 @@ micronautBom {
 }
 
 dependencies {
-    // jdbi
-    implementation platform("org.jdbi:jdbi3-bom:$jdbiVersion")
     
     constraints {
 
@@ -45,8 +43,12 @@ dependencies {
         api "org.mariadb.jdbc:mariadb-java-client:$mariadbDriverVersion"
         api "mysql:mysql-connector-java:$mysqlDriverVersion"
 
+
+        // jdbi
+        platform("org.jdbi:jdbi3-bom:$jdbiVersion")
+
         // Will remove these - just want to chat about it first
-        //api "org.jdbi:jdbi3-core:$jdbiVersion"
+        api "org.jdbi:jdbi3-core"
         //api "org.jdbi:jdbi3-sqlobject:$jdbiVersion"
         //api "org.jdbi:jdbi3-guava:$jdbiVersion"
         //api "org.jdbi:jdbi3-jodatime2:$jdbiVersion"

--- a/sql-bom/build.gradle
+++ b/sql-bom/build.gradle
@@ -9,6 +9,9 @@ micronautBom {
 }
 
 dependencies {
+    // jdbi
+    implementation platform("org.jdbi:jdbi3-bom:$jdbiVersion")
+    
     constraints {
 
         // vertx client
@@ -42,9 +45,6 @@ dependencies {
         api "org.mariadb.jdbc:mariadb-java-client:$mariadbDriverVersion"
         api "mysql:mysql-connector-java:$mysqlDriverVersion"
 
-        // jdbi
-        api platform("org.jdbi:jdbi3-bom:$jdbiVersion")
-        
         // Will remove these - just want to chat about it first
         //api "org.jdbi:jdbi3-core:$jdbiVersion"
         //api "org.jdbi:jdbi3-sqlobject:$jdbiVersion"

--- a/sql-bom/build.gradle
+++ b/sql-bom/build.gradle
@@ -43,6 +43,20 @@ dependencies {
         api "mysql:mysql-connector-java:$mysqlDriverVersion"
 
         // jdbi
-        api "org.jdbi:jdbi3-core:$jdbiVersion"
+        api platform("org.jdbi:jdbi3-bom:$jdbiVersion")
+        
+        // Will remove these - just want to chat about it first
+        //api "org.jdbi:jdbi3-core:$jdbiVersion"
+        //api "org.jdbi:jdbi3-sqlobject:$jdbiVersion"
+        //api "org.jdbi:jdbi3-guava:$jdbiVersion"
+        //api "org.jdbi:jdbi3-jodatime2:$jdbiVersion"
+        //api "org.jdbi:jdbi3-jpa:$jdbiVersion"
+        //api "org.jdbi:jdbi3-kotlin:$jdbiVersion"
+        //api "org.jdbi:jdbi3-kotlin-sqlobject:$jdbiVersion"
+        //api "org.jdbi:jdbi3-oracle12:$jdbiVersion"
+        //api "org.jdbi:jdbi3-postgres:$jdbiVersion"
+        //api "org.jdbi:jdbi3-spring5:$jdbiVersion"
+        //api "org.jdbi:jdbi3-stringtemplate4:$jdbiVersion"
+        //api "org.jdbi:jdbi3-vavr:$jdbiVersion"
     }
 }

--- a/sql-bom/build.gradle
+++ b/sql-bom/build.gradle
@@ -9,6 +9,7 @@ micronautBom {
 }
 
 dependencies {
+    api platform("org.jdbi:jdbi3-bom:$jdbiVersion")
     
     constraints {
 
@@ -42,10 +43,6 @@ dependencies {
         api "com.oracle.database.jdbc:ojdbc8:$ojdbcVersion"
         api "org.mariadb.jdbc:mariadb-java-client:$mariadbDriverVersion"
         api "mysql:mysql-connector-java:$mysqlDriverVersion"
-
-
-        // jdbi
-        platform("org.jdbi:jdbi3-bom:$jdbiVersion")
 
         // Will remove these - just want to chat about it first
         api "org.jdbi:jdbi3-core"

--- a/sql-bom/build.gradle
+++ b/sql-bom/build.gradle
@@ -44,18 +44,6 @@ dependencies {
         api "org.mariadb.jdbc:mariadb-java-client:$mariadbDriverVersion"
         api "mysql:mysql-connector-java:$mysqlDriverVersion"
 
-        // Will remove these - just want to chat about it first
         api "org.jdbi:jdbi3-core"
-        //api "org.jdbi:jdbi3-sqlobject:$jdbiVersion"
-        //api "org.jdbi:jdbi3-guava:$jdbiVersion"
-        //api "org.jdbi:jdbi3-jodatime2:$jdbiVersion"
-        //api "org.jdbi:jdbi3-jpa:$jdbiVersion"
-        //api "org.jdbi:jdbi3-kotlin:$jdbiVersion"
-        //api "org.jdbi:jdbi3-kotlin-sqlobject:$jdbiVersion"
-        //api "org.jdbi:jdbi3-oracle12:$jdbiVersion"
-        //api "org.jdbi:jdbi3-postgres:$jdbiVersion"
-        //api "org.jdbi:jdbi3-spring5:$jdbiVersion"
-        //api "org.jdbi:jdbi3-stringtemplate4:$jdbiVersion"
-        //api "org.jdbi:jdbi3-vavr:$jdbiVersion"
     }
 }

--- a/sql-bom/build.gradle
+++ b/sql-bom/build.gradle
@@ -44,6 +44,7 @@ dependencies {
         api "org.mariadb.jdbc:mariadb-java-client:$mariadbDriverVersion"
         api "mysql:mysql-connector-java:$mysqlDriverVersion"
 
+        // jdbi
         api "org.jdbi:jdbi3-core"
     }
 }


### PR DESCRIPTION
Correct me if I'm wrong on how bom files work - this is a new use case for me - but we can use a platform here to establish the jdbi3 dependencies rather than manually establishing all of the jdbi versions ourselves.

This way I can avoid manually defining the version number for any of the jdbi modules I want to use.