### PR TITLE
Revert "Use jdbi3-bom platform instead of jdbi-core (#535)"

### DIFF
--- a/sql-bom/build.gradle
+++ b/sql-bom/build.gradle
@@ -9,8 +9,6 @@ micronautBom {
 }
 
 dependencies {
-    api platform("org.jdbi:jdbi3-bom:$jdbiVersion")
-    
     constraints {
 
         // vertx client
@@ -45,6 +43,6 @@ dependencies {
         api "mysql:mysql-connector-java:$mysqlDriverVersion"
 
         // jdbi
-        api "org.jdbi:jdbi3-core"
+        api "org.jdbi:jdbi3-core:$jdbiVersion"
     }
 }


### PR DESCRIPTION
This reverts commit 03f46a2a947a4deb9749cb364c2b90e64739c7f1.

We believe this has uncovered a bug in Gradle which prevents resolution of the SQL
BOM downstream.

See: https://github.com/micronaut-projects/micronaut-core/issues/7068

Reverting whilst investigations continue