### PR TITLE
Fix BOM generation

### DIFF
--- a/sql-bom/build.gradle
+++ b/sql-bom/build.gradle
@@ -9,6 +9,8 @@ micronautBom {
 }
 
 dependencies {
+    api platform("org.jdbi:jdbi3-bom:$jdbiVersion")
+    
     constraints {
 
         // vertx client
@@ -43,6 +45,6 @@ dependencies {
         api "mysql:mysql-connector-java:$mysqlDriverVersion"
 
         // jdbi
-        api "org.jdbi:jdbi3-core:$jdbiVersion"
+        api "org.jdbi:jdbi3-core"
     }
 }

--- a/sql-bom/build.gradle
+++ b/sql-bom/build.gradle
@@ -43,8 +43,5 @@ dependencies {
         api "com.oracle.database.jdbc:ojdbc8:$ojdbcVersion"
         api "org.mariadb.jdbc:mariadb-java-client:$mariadbDriverVersion"
         api "mysql:mysql-connector-java:$mysqlDriverVersion"
-
-        // jdbi
-        api "org.jdbi:jdbi3-core"
     }
 }


### PR DESCRIPTION
This fixes the root cause for https://github.com/micronaut-projects/micronaut-core/issues/7068
which is that the BOM we generated contained a constraint without version.

Constraints without versions do not make sense: the role of a constraint
_is_ to influence dependency resolution by providing at least a version.
This should have been caught by Gradle and should in any case not trigger
a parsing bug (see https://github.com/gradle/gradle/issues/20182) but
that's how it is.