### PR TITLE
Add ability to configure ConnectionProvider for jOOQ

### DIFF
--- a/config/accepted-api-changes.json
+++ b/config/accepted-api-changes.json
@@ -1,0 +1,12 @@
+[
+  {
+    "type": "io.micronaut.configuration.jooq.JooqConfigurationFactory",
+    "member": "Class io.micronaut.configuration.jooq.JooqConfigurationFactory",
+    "reason": "Ability to use custom org.jooq.ConnectionProvider"
+  },
+  {
+    "type": "io.micronaut.configuration.jooq.JooqConfigurationFactory",
+    "member": "Method io.micronaut.configuration.jooq.JooqConfigurationFactory.jooqConfiguration(java.lang.String,javax.sql.DataSource,org.jooq.TransactionProvider,org.jooq.conf.Settings,org.jooq.ExecutorProvider,org.jooq.RecordMapperProvider,org.jooq.RecordUnmapperProvider,org.jooq.MetaProvider,org.jooq.ConverterProvider,io.micronaut.context.ApplicationContext)",
+    "reason": "Ability to use custom org.jooq.ConnectionProvider"
+  }
+]

--- a/jooq/src/main/java/io/micronaut/configuration/jooq/JooqConfigurationFactory.java
+++ b/jooq/src/main/java/io/micronaut/configuration/jooq/JooqConfigurationFactory.java
@@ -65,6 +65,7 @@ public class JooqConfigurationFactory {
             @Parameter @Nullable RecordUnmapperProvider recordUnmapperProvider,
             @Parameter @Nullable MetaProvider metaProvider,
             @Parameter @Nullable ConverterProvider converterProvider,
+            @Parameter @Nullable ConnectionProvider connectionProvider,
             ApplicationContext ctx
     ) {
         DefaultConfiguration configuration = new DefaultConfiguration();
@@ -74,9 +75,13 @@ public class JooqConfigurationFactory {
         DataSourceResolver dataSourceResolver = ctx.findBean(DataSourceResolver.class).orElse(DataSourceResolver.DEFAULT);
         configuration.setSQLDialect(properties.determineSqlDialect(dataSourceResolver.resolve(dataSource)));
 
-        configuration.setDataSource(dataSource);
         if (transactionProvider != null) {
             configuration.setTransactionProvider(transactionProvider);
+        }
+        if (connectionProvider != null) {
+            configuration.setConnectionProvider(connectionProvider);
+        } else {
+            configuration.setDataSource(dataSource);
         }
         if (settings != null) {
             configuration.setSettings(settings);

--- a/src/main/docs/guide/jooq.adoc
+++ b/src/main/docs/guide/jooq.adoc
@@ -41,6 +41,7 @@ Micronaut will look for the following bean types:
 
 * link:{jooqapi}/org/jooq/conf/Settings.html[Settings]
 * link:{jooqapi}/org/jooq/TransactionProvider.html[TransactionProvider]
+* link:{jooqapi}/org/jooq/ConnectionProvider.html[ConnectionProvider]
 * link:{jooqapi}/org/jooq/ExecutorProvider.html[ExecutorProvider]
 * link:{jooqapi}/org/jooq/RecordMapperProvider.html[RecordMapperProvider]
 * link:{jooqapi}/org/jooq/RecordUnmapperProvider.html[RecordUnmapperProvider]


### PR DESCRIPTION
There was no way to configure custom `ConnectionProvider` so this PR adds one. 

The use case for this is to configure custom `ConnectionProvider` that sets authentication variables in every transaction for logging using trigger.