### PR TITLE
build: downgrade to Jooq 3.15.10

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,7 +9,7 @@ micronaut-gradle-plugin = "3.4.1"
 # Frameworks
 
 managed-vertx = "4.3.1"
-managed-jooq = "3.15.0"
+managed-jooq = "3.15.11"
 managed-hibernate = "5.6.9.Final"
 managed-hibernate-reactive = "1.1.6.Final"
 managed-jasync = "2.0.8"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,7 +9,7 @@ micronaut-gradle-plugin = "3.4.1"
 # Frameworks
 
 managed-vertx = "4.3.1"
-managed-jooq = "3.16.7"
+managed-jooq = "3.15.0"
 managed-hibernate = "5.6.9.Final"
 managed-hibernate-reactive = "1.1.6.Final"
 managed-jasync = "2.0.8"


### PR DESCRIPTION
Jooq 3.16 Open-source edition requires JDK 11

> Drop Java 6/7 support for Enterprise Edition, require Java 11 in OSS Edition