### PR TITLE
Duplicate managed-commons-dbcp depenedency for core compatibility

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,6 +24,8 @@ managed-mssql-driver = "9.4.1.jre8"
 managed-mysql-driver = "8.0.29"
 
 # JDBC Pools
+# Required to keep catalog compatibility with 3.4.x.  Can be removed for 4.0.0
+managed-commons-dbcp-compat = "2.9.0"
 
 managed-hikari = "4.0.3"
 managed-commons-dbcp = "2.9.0"
@@ -81,6 +83,8 @@ jdbi3-sqlobject = { module = "org.jdbi:jdbi3-sqlobject", version.ref = "managed-
 jdbi3-core = { module = "org.jdbi:jdbi3-core", version.ref = "managed-jdbi" }
 
 # JDBC pools
+# Duplicated to keep catalog compatibility with 3.4.x.  Can be removed for 4.0.0
+managed-commons-dbcp = { module = "org.apache.commons:commons-dbcp2", version.ref = "managed-commons-dbcp-compat" }
 
 managed-hikaricp = { module = "com.zaxxer:HikariCP", version.ref = "managed-hikari" }
 managed-commons-dbcp2 = { module = "org.apache.commons:commons-dbcp2", version.ref = "managed-commons-dbcp" }


### PR DESCRIPTION
We used to declare managed-commons-dbcp in the core catalog.  We want to remove this for ease of
maintenance, but this means we would break compatibility as here it's managed-commons-dbcp2.

This PR adds a temporary duplication of the catalog to keep managed-commons-dbcp in the catalog here

This can be removed for 4.0.0

Removal was here https://github.com/micronaut-projects/micronaut-core/pull/7364