### PR TITLE
Duplicate managed-commons-dbcp depenedency for core compatibility 

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,6 +5,8 @@ managed-hibernate = "5.6.9.Final"
 managed-jasync = "1.2.3"
 managed-hikari = "4.0.3"
 managed-commons-dbcp = "2.9.0"
+# Required to keep catalog compatibility with 3.4.x.  Can be removed for 4.0.0
+managed-commons-dbcp-compat = "2.9.0"
 managed-tomcat-jdbc = "10.0.21"
 managed-ojdbc = "21.5.0.0"
 managed-postgres-driver = "42.3.6"
@@ -43,6 +45,8 @@ managed-jasync-mysql = { module = "com.github.jasync-sql:jasync-mysql", version.
 managed-jasync-postgresql = { module = "com.github.jasync-sql:jasync-postgresql", version.ref = "managed-jasync" }
 managed-hikaricp = { module = "com.zaxxer:HikariCP", version.ref = "managed-hikari" }
 managed-commons-dbcp2 = { module = "org.apache.commons:commons-dbcp2", version.ref = "managed-commons-dbcp" }
+# Duplicated to keep catalog compatibility with 3.4.x.  Can be removed for 4.0.0
+managed-commons-dbcp = { module = "org.apache.commons:commons-dbcp2", version.ref = "managed-commons-dbcp-compat" }
 managed-tomcat-jdbc = { module = "org.apache.tomcat:tomcat-jdbc", version.ref = "managed-tomcat-jdbc" }
 managed-ucp = { module = "com.oracle.database.jdbc:ucp", version.ref = "managed-ojdbc" }
 managed-postgresql = { module = "org.postgresql:postgresql", version.ref = "managed-postgres-driver" }

--- a/settings.gradle
+++ b/settings.gradle
@@ -6,7 +6,7 @@ pluginManagement {
 }
 
 plugins {
-    id("io.micronaut.build.shared.settings") version "5.3.9"
+    id("io.micronaut.build.shared.settings") version "5.3.10"
 }
 
 rootProject.name = 'sql-parent'


### PR DESCRIPTION
I am cherry picking this https://github.com/micronaut-projects/micronaut-sql/commit/8e56d405497605ee286beac23c23fd4d12f04eeb to release in in 4.4.x which will be part of Micronaut 3.5.3