### PR TITLE
build: Stop publishing jooq as a Java 11 jar

### DIFF
--- a/jooq/build.gradle
+++ b/jooq/build.gradle
@@ -2,14 +2,6 @@ plugins {
     id 'io.micronaut.build.internal.sql-module'
 }
 
-micronautBuild {
-    sourceCompatibility = "11"
-    targetCompatibility = "11"
-    binaryCompatibility {
-        enabled.set(false)
-    }
-}
-
 sourceSets {
     txTest {
         compileClasspath += main.output


### PR DESCRIPTION
When we upgraded Jooq to the Java 11 version, we switched the build to be able to use it

When we downgraded Jooq as we have to support java 8 until MN4, we forgot to remove the
switch in the build