### PR TITLE
bug: SqlServerDriverStringProperty is initialized at build time

### DIFF
--- a/jdbc/src/main/java/io/micronaut/jdbc/nativeimage/JdbcFeature.java
+++ b/jdbc/src/main/java/io/micronaut/jdbc/nativeimage/JdbcFeature.java
@@ -244,7 +244,8 @@ final class JdbcFeature implements Feature {
             initializeAtBuildTime(access,
                     SQL_SERVER_DRIVER,
                     "com.microsoft.sqlserver.jdbc.Util",
-                    "com.microsoft.sqlserver.jdbc.SQLServerException"
+                    "com.microsoft.sqlserver.jdbc.SQLServerException",
+                    "com.microsoft.sqlserver.jdbc.SQLServerDriverStringProperty"
             );
 
             addResourcePatterns(


### PR DESCRIPTION
This will fix https://github.com/micronaut-projects/micronaut-sql/issues/703 once it's included in the core bom