### PR TITLE
Extended GraalVM HibernateFeature

### DIFF
--- a/hibernate-jpa/src/main/java/io/micronaut/configuration/hibernate/jpa/graal/HibernateFeature.java
+++ b/hibernate-jpa/src/main/java/io/micronaut/configuration/hibernate/jpa/graal/HibernateFeature.java
@@ -83,6 +83,29 @@ final class HibernateFeature implements Feature {
 
         registerIfPresent(access, "com.mysql.cj.jdbc.Driver", mysqlDialects);
         registerIfPresent(access, "io.vertx.mysqlclient.spi.MySQLDriver", mysqlDialects);
+
+        AutomaticFeatureUtils.registerConstructorsForRuntimeReflection(
+            access, "org.hibernate.persister.entity.JoinedSubclassEntityPersister");
+        AutomaticFeatureUtils.registerConstructorsForRuntimeReflection(
+            access, "org.hibernate.persister.entity.SingleTableEntityPersister");
+        AutomaticFeatureUtils.registerConstructorsForRuntimeReflection(
+            access, "org.hibernate.persister.entity.UnionSubclassEntityPersister");
+        AutomaticFeatureUtils.registerConstructorsForRuntimeReflection(
+            access, "org.hibernate.persister.collection.OneToManyPersister");
+        AutomaticFeatureUtils.registerConstructorsForRuntimeReflection(
+            access, "org.hibernate.persister.collection.BasicCollectionPersister");
+
+        AutomaticFeatureUtils.registerConstructorsForRuntimeReflection(
+            access, "org.hibernate.sql.ordering.antlr.NodeSupport");
+        AutomaticFeatureUtils.registerConstructorsForRuntimeReflection(
+            access, "org.hibernate.sql.ordering.antlr.SortKey");
+        AutomaticFeatureUtils.registerConstructorsForRuntimeReflection(
+            access, "org.hibernate.sql.ordering.antlr.OrderingSpecification");
+        AutomaticFeatureUtils.registerConstructorsForRuntimeReflection(
+            access, "org.hibernate.sql.ordering.antlr.SortSpecification");
+        AutomaticFeatureUtils.registerClassForRuntimeReflectionAndReflectiveInstantiation(
+            access, "org.hibernate.sql.ordering.antlr.OrderByFragment");
+        AutomaticFeatureUtils.registerConstructorsForRuntimeReflection(access, "antlr.CommonToken");
     }
 
     private void registerIfPresent(BeforeAnalysisAccess access, String name, Class<?>... dialects) {


### PR DESCRIPTION
According to the [discussion](https://github.com/micronaut-projects/micronaut-core/discussions/8071) held in the micronaut-core project.

This PR extends the `HibernateFeature` with essentials hints for GraalVM where Hibernate works with reflection. It supports

- Hibernate persisters for hierarchic entities
- Basic or one-to-many persisters
- ANTLR based stuff such as (@OrderBy, …)