### PR TITLE
fix: JooqConfigurationFactory visibility back to public

### DIFF
--- a/jooq/src/main/java/io/micronaut/configuration/jooq/AbstractJooqConfigurationFactory.java
+++ b/jooq/src/main/java/io/micronaut/configuration/jooq/AbstractJooqConfigurationFactory.java
@@ -17,7 +17,6 @@ package io.micronaut.configuration.jooq;
 
 import io.micronaut.context.ApplicationContext;
 import io.micronaut.context.annotation.Parameter;
-import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.inject.qualifiers.Qualifiers;
 import org.jooq.ConverterProvider;
@@ -40,8 +39,7 @@ import org.jooq.impl.DefaultConfiguration;
  * @author Vladimir Kulev
  * @since 1.2.0
  */
-@Internal
-abstract class AbstractJooqConfigurationFactory {
+public class AbstractJooqConfigurationFactory {
 
     /**
      * Creates jOOQ {@link org.jooq.Configuration}.

--- a/jooq/src/main/java/io/micronaut/configuration/jooq/JooqConfigurationFactory.java
+++ b/jooq/src/main/java/io/micronaut/configuration/jooq/JooqConfigurationFactory.java
@@ -19,7 +19,6 @@ import io.micronaut.context.ApplicationContext;
 import io.micronaut.context.annotation.EachBean;
 import io.micronaut.context.annotation.Factory;
 import io.micronaut.context.annotation.Parameter;
-import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.jdbc.DataSourceResolver;
 import org.jooq.Configuration;
@@ -42,8 +41,7 @@ import javax.sql.DataSource;
  * @since 1.2.0
  */
 @Factory
-@Internal
-final class JooqConfigurationFactory extends AbstractJooqConfigurationFactory {
+public class JooqConfigurationFactory extends AbstractJooqConfigurationFactory {
 
     /**
      * Creates jOOQ {@link Configuration}.

--- a/jooq/src/main/java/io/micronaut/configuration/jooq/R2dbcJooqConfigurationFactory.java
+++ b/jooq/src/main/java/io/micronaut/configuration/jooq/R2dbcJooqConfigurationFactory.java
@@ -20,7 +20,6 @@ import io.micronaut.context.annotation.EachBean;
 import io.micronaut.context.annotation.Factory;
 import io.micronaut.context.annotation.Parameter;
 import io.micronaut.context.annotation.Requires;
-import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.Nullable;
 import io.r2dbc.spi.ConnectionFactory;
 import org.jooq.Configuration;
@@ -41,9 +40,8 @@ import org.jooq.impl.DefaultConfiguration;
  * @since 4.5.0
  */
 @Requires(classes = ConnectionFactory.class)
-@Internal
 @Factory
-final class R2dbcJooqConfigurationFactory extends AbstractJooqConfigurationFactory {
+public class R2dbcJooqConfigurationFactory extends AbstractJooqConfigurationFactory {
 
     /**
      * Creates jOOQ {@link Configuration}. It will configure it with available jOOQ provider beans with the same


### PR DESCRIPTION
Close: https://github.com/micronaut-projects/micronaut-sql/issues/730

We accidentally change JooqConfigurationFactory visibility from public to private in a minor version in this PR: https://github.com/micronaut-projects/micronaut-sql/pull/678

This makes this class public again.