### PR TITLE
fix: add deprecate DSLContextFactory::dslContext

### DIFF
--- a/jooq/src/main/java/io/micronaut/configuration/jooq/DSLContextFactory.java
+++ b/jooq/src/main/java/io/micronaut/configuration/jooq/DSLContextFactory.java
@@ -17,7 +17,6 @@ package io.micronaut.configuration.jooq;
 
 import io.micronaut.context.annotation.EachBean;
 import io.micronaut.context.annotation.Factory;
-import io.micronaut.core.annotation.Internal;
 import org.jooq.Configuration;
 import org.jooq.DSLContext;
 import org.jooq.impl.DefaultDSLContext;
@@ -29,8 +28,7 @@ import org.jooq.impl.DefaultDSLContext;
  * @since 4.5.0
  */
 @Factory
-@Internal
-final class DSLContextFactory {
+public class DSLContextFactory {
 
     /**
      * Created {@link DSLContext} based on {@link Configuration}.

--- a/jooq/src/main/java/io/micronaut/configuration/jooq/JooqConfigurationFactory.java
+++ b/jooq/src/main/java/io/micronaut/configuration/jooq/JooqConfigurationFactory.java
@@ -21,9 +21,11 @@ import io.micronaut.context.annotation.Factory;
 import io.micronaut.context.annotation.Parameter;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.jdbc.DataSourceResolver;
+import jdk.jshell.spi.ExecutionControl;
 import org.jooq.Configuration;
 import org.jooq.ConnectionProvider;
 import org.jooq.ConverterProvider;
+import org.jooq.DSLContext;
 import org.jooq.ExecutorProvider;
 import org.jooq.MetaProvider;
 import org.jooq.RecordMapperProvider;
@@ -104,6 +106,18 @@ public class JooqConfigurationFactory extends AbstractJooqConfigurationFactory {
         }
 
         return configuration;
+    }
+
+    /**
+     * Created {@link DSLContext} based on {@link Configuration}.
+     *
+     * @param configuration The {@link Configuration}
+     * @return A {@link DSLContext}
+     * @deprecated Handled via the {@link DSLContextFactory} instead.
+     */
+    @Deprecated
+    public DSLContext dslContext(Configuration configuration) {
+        throw new UnsupportedOperationException("Moved to DSLContextFactory");
     }
 
 }


### PR DESCRIPTION
Close https://github.com/micronaut-projects/micronaut-sql/issues/730

https://github.com/micronaut-projects/micronaut-sql/pull/678 accidentally removed the public method DSLContextFactory:: dslContext

It moved its logic to DSLContextFactory. This PR makes DSLContextFactory public and adds the method back annotated with @Deprecated.