### PR TITLE
Enabled and fixed native image tests

### DIFF
--- a/buildSrc/src/main/groovy/io.micronaut.build.internal.test-application.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.build.internal.test-application.gradle
@@ -30,16 +30,6 @@ application {
     mainClass = "example.Application"
 }
 
-// TODO: Re-enable native tests once we have Micronaut data for 4.0.0
-project.afterEvaluate {
-    tasks.named("testNativeImage") {
-        onlyIf { false }
-    }
-    tasks.named("nativeCompile") {
-        onlyIf { false }
-    }
-}
-
 graalvmNative {
     binaries {
         main {

--- a/hibernate-jpa/src/main/java/io/micronaut/configuration/hibernate/jpa/graal/HibernateSubstitutions.java
+++ b/hibernate-jpa/src/main/java/io/micronaut/configuration/hibernate/jpa/graal/HibernateSubstitutions.java
@@ -204,7 +204,6 @@ final class Loggers {
         ImplicitNamingStrategyJpaCompliantImpl.class
 }, typeNames = {
         "org.hibernate.event.spi.AutoFlushEventListener[]",
-        "org.hibernate.event.spi.PersistEventListener[]",
         "org.hibernate.event.spi.ClearEventListener[]",
         "org.hibernate.event.spi.DeleteEventListener[]",
         "org.hibernate.event.spi.DirtyCheckEventListener[]",

--- a/hibernate-jpa/src/main/resources/META-INF/native-image/io.micronaut.sql/hibernate-jpa-graal/native-image.properties
+++ b/hibernate-jpa/src/main/resources/META-INF/native-image/io.micronaut.sql/hibernate-jpa-graal/native-image.properties
@@ -14,5 +14,4 @@
 # limitations under the License.
 #
 
-Args = --initialize-at-build-time=org.jboss.logging,ch.qos.logback,org.slf4j,org.hibernate.internal,org.hibernate.jmx,org.hibernate.query \
-       --initialize-at-run-time=io.micronaut.configuration.hibernate.jpa.jcache.$HibernateJCacheManagerBinder$Definition,io.micronaut.configuration.hibernate.jpa.metrics.$HibernateMetricsBinder$Definition
+Args = --initialize-at-run-time=io.micronaut.configuration.hibernate.jpa.jcache.$HibernateJCacheManagerBinder$Definition,io.micronaut.configuration.hibernate.jpa.metrics.$HibernateMetricsBinder$Definition

--- a/hibernate-jpa/src/main/resources/META-INF/native-image/io.micronaut.sql/hibernate-jpa-graal/native-image.properties
+++ b/hibernate-jpa/src/main/resources/META-INF/native-image/io.micronaut.sql/hibernate-jpa-graal/native-image.properties
@@ -14,4 +14,4 @@
 # limitations under the License.
 #
 
-Args = --initialize-at-run-time=io.micronaut.configuration.hibernate.jpa.jcache.$HibernateJCacheManagerBinder$Definition,io.micronaut.configuration.hibernate.jpa.metrics.$HibernateMetricsBinder$Definition
+Args = --initialize-at-run-time=io.micronaut.configuration.hibernate.jpa.metrics.$HibernateMetricsBinder$Definition

--- a/hibernate-jpa/src/main/resources/META-INF/native-image/io.micronaut.sql/hibernate-jpa-graal/native-image.properties
+++ b/hibernate-jpa/src/main/resources/META-INF/native-image/io.micronaut.sql/hibernate-jpa-graal/native-image.properties
@@ -14,5 +14,5 @@
 # limitations under the License.
 #
 
-Args = --initialize-at-build-time=org.jboss.logging,org.hibernate.internal,org.hibernate.jmx,org.hibernate.query \
+Args = --initialize-at-build-time=org.jboss.logging,ch.qos.logback,org.slf4j,org.hibernate.internal,org.hibernate.jmx,org.hibernate.query \
        --initialize-at-run-time=io.micronaut.configuration.hibernate.jpa.jcache.$HibernateJCacheManagerBinder$Definition,io.micronaut.configuration.hibernate.jpa.metrics.$HibernateMetricsBinder$Definition

--- a/hibernate-reactive/src/main/resources/META-INF/native-image/io.micronaut.sql/hibernate-jpa-graal/native-image.properties
+++ b/hibernate-reactive/src/main/resources/META-INF/native-image/io.micronaut.sql/hibernate-jpa-graal/native-image.properties
@@ -14,5 +14,4 @@
 # limitations under the License.
 #
 
-Args = --initialize-at-build-time=org.jboss.logging,org.hibernate.internal,org.hibernate.jmx,org.hibernate.query \
-       --initialize-at-run-time=io.micronaut.configuration.hibernate.jpa.jcache.$HibernateJCacheManagerBinder$Definition,io.micronaut.configuration.hibernate.jpa.metrics.$HibernateMetricsBinder$Definition
+Args = --initialize-at-run-time=io.micronaut.configuration.hibernate.jpa.metrics.$HibernateMetricsBinder$Definition

--- a/hibernate-reactive/src/main/resources/META-INF/native-image/io.micronaut.sql/hibernate-jpa-graal/reflect-config.json
+++ b/hibernate-reactive/src/main/resources/META-INF/native-image/io.micronaut.sql/hibernate-jpa-graal/reflect-config.json
@@ -1,0 +1,16 @@
+[
+  {
+    "name": "org.hibernate.internal.log.ConnectionPoolingLogger_$logger",
+    "condition": {
+      "typeReachable": "org.hibernate.internal.log.ConnectionPoolingLogger"
+    },
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.jboss.logging.Logger"
+        ]
+      }
+    ]
+  }
+]

--- a/hibernate6-jpa/src/main/java/io/micronaut/configuration/hibernate6/jpa/graal/HibernateSubstitutions.java
+++ b/hibernate6-jpa/src/main/java/io/micronaut/configuration/hibernate6/jpa/graal/HibernateSubstitutions.java
@@ -27,11 +27,11 @@ import com.oracle.svm.core.annotate.TargetClass;
 import io.micronaut.core.annotation.TypeHint;
 import io.micronaut.core.annotation.TypeHint.AccessType;
 import io.micronaut.jdbc.spring.HibernatePresenceCondition;
+import org.hibernate.boot.ResourceStreamLocator;
 import org.hibernate.boot.archive.spi.InputStreamAccess;
 import org.hibernate.boot.jaxb.internal.MappingBinder;
 import org.hibernate.boot.jaxb.spi.Binding;
 import org.hibernate.boot.model.naming.ImplicitNamingStrategyJpaCompliantImpl;
-import org.hibernate.boot.registry.classloading.spi.ClassLoaderService;
 import org.hibernate.id.Assigned;
 import org.hibernate.id.ForeignGenerator;
 import org.hibernate.id.GUIDGenerator;
@@ -86,7 +86,6 @@ final class Loggers {
         ImplicitNamingStrategyJpaCompliantImpl.class
 }, typeNames = {
         "org.hibernate.event.spi.AutoFlushEventListener[]",
-        "org.hibernate.event.spi.PersistEventListener[]",
         "org.hibernate.event.spi.ClearEventListener[]",
         "org.hibernate.event.spi.DeleteEventListener[]",
         "org.hibernate.event.spi.DirtyCheckEventListener[]",
@@ -212,7 +211,7 @@ final class NoopXmlMappingBinderAccess {
 @Substitute
 final class NoopSchemaResolver implements XMLResolver {
     @Substitute
-    public NoopSchemaResolver(ClassLoaderService classLoaderService) {
+    public NoopSchemaResolver(ResourceStreamLocator resourceStreamLocator) {
     }
 
     @Override

--- a/hibernate6-jpa/src/main/resources/META-INF/native-image/io.micronaut.sql/hibernate-jpa-graal/native-image.properties
+++ b/hibernate6-jpa/src/main/resources/META-INF/native-image/io.micronaut.sql/hibernate-jpa-graal/native-image.properties
@@ -14,5 +14,4 @@
 # limitations under the License.
 #
 
-Args = --initialize-at-build-time=org.jboss.logging,org.hibernate.internal,org.hibernate.jmx,org.hibernate.query \
-       --initialize-at-run-time=io.micronaut.configuration.hibernate6.jpa.jcache.$HibernateJCacheManagerBinder$Definition,io.micronaut.configuration.hibernate6.jpa.metrics.$HibernateMetricsBinder$Definition
+Args = --initialize-at-run-time=io.micronaut.configuration.hibernate6.jpa.metrics.$HibernateMetricsBinder$Definition

--- a/jdbc/src/main/java/io/micronaut/jdbc/nativeimage/JdbcFeature.java
+++ b/jdbc/src/main/java/io/micronaut/jdbc/nativeimage/JdbcFeature.java
@@ -28,8 +28,6 @@ import static io.micronaut.core.graal.AutomaticFeatureUtils.addResourceBundles;
 import static io.micronaut.core.graal.AutomaticFeatureUtils.addResourcePatterns;
 import static io.micronaut.core.graal.AutomaticFeatureUtils.initializeAtBuildTime;
 import static io.micronaut.core.graal.AutomaticFeatureUtils.initializeAtRunTime;
-import static io.micronaut.core.graal.AutomaticFeatureUtils.initializePackagesAtBuildTime;
-import static io.micronaut.core.graal.AutomaticFeatureUtils.initializePackagesAtRunTime;
 import static io.micronaut.core.graal.AutomaticFeatureUtils.registerAllForRuntimeReflection;
 import static io.micronaut.core.graal.AutomaticFeatureUtils.registerClassForRuntimeReflection;
 import static io.micronaut.core.graal.AutomaticFeatureUtils.registerClassForRuntimeReflectionAndReflectiveInstantiation;
@@ -51,7 +49,6 @@ final class JdbcFeature implements Feature {
     private static final String H2_DRIVER = "org.h2.Driver";
     private static final String POSTGRESQL_DRIVER = "org.postgresql.Driver";
     private static final String SQL_SERVER_DRIVER = "com.microsoft.sqlserver.jdbc.SQLServerDriver";
-    private static final String MARIADB_DRIVER = "org.mariadb.jdbc.Driver";
     private static final String MYSQL_DRIVER = "com.mysql.cj.jdbc.Driver";
 
     @Override
@@ -59,8 +56,6 @@ final class JdbcFeature implements Feature {
         handleH2(access);
 
         handlePostgres(access);
-
-        handleMariadb(access);
 
         handleSqlServer(access);
 
@@ -119,24 +114,6 @@ final class JdbcFeature implements Feature {
             registerAllForRuntimeReflection(access, "org.postgresql.PGProperty");
 
             addResourcePatterns("META-INF/services/java.sql.Driver");
-
-            initializeAtBuildTime(access, "java.sql.DriverManager");
-        }
-    }
-
-    private void handleMariadb(BeforeAnalysisAccess access) {
-        Class<?> mariaDriver = access.findClassByName(MARIADB_DRIVER);
-        if (mariaDriver != null) {
-            registerFieldsAndMethodsWithReflectiveAccess(access, MARIADB_DRIVER);
-
-            addResourcePatterns("META-INF/services/java.sql.Driver");
-
-            registerFieldsAndMethodsWithReflectiveAccess(access, "org.mariadb.jdbc.util.Options");
-
-            initializePackagesAtBuildTime("org.mariadb");
-            initializePackagesAtRunTime("org.mariadb.jdbc.credential.aws");
-            initializePackagesAtRunTime("org.mariadb.jdbc.internal.failover.impl");
-            initializeAtRunTime(access, "org.mariadb.jdbc.internal.com.send.authentication.SendPamAuthPacket");
 
             initializeAtBuildTime(access, "java.sql.DriverManager");
         }

--- a/jdbc/src/main/resources/META-INF/native-image/io.micronaut.sql/micronaut-jdbc/reflect-config.json
+++ b/jdbc/src/main/resources/META-INF/native-image/io.micronaut.sql/micronaut-jdbc/reflect-config.json
@@ -1,0 +1,28 @@
+[
+  {
+    "condition": {
+      "typeReachable": "org.mariadb.jdbc.Configuration"
+    },
+    "name": "org.mariadb.jdbc.Configuration",
+    "allDeclaredFields": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.mariadb.jdbc.Configuration"
+    },
+    "name": "org.mariadb.jdbc.Configuration$Builder",
+    "allDeclaredFields": true
+  },
+  {
+    "condition": {
+      "typeReachable": "org.mariadb.jdbc.plugin.authentication.standard.NativePasswordPlugin"
+    },
+    "name": "sun.security.provider.SHA",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  }
+]

--- a/jdbc/src/main/resources/META-INF/native-image/io.micronaut.sql/micronaut-jdbc/resource-config.json
+++ b/jdbc/src/main/resources/META-INF/native-image/io.micronaut.sql/micronaut-jdbc/resource-config.json
@@ -1,0 +1,13 @@
+{
+  "bundles": [],
+  "resources": {
+    "includes": [
+      {
+        "condition": {
+          "typeReachable": "org.mariadb.jdbc.util.VersionFactory"
+        },
+        "pattern": "\\Qmariadb.properties\\E"
+      }
+    ]
+  }
+}

--- a/tests/common-reactive/build.gradle
+++ b/tests/common-reactive/build.gradle
@@ -9,6 +9,7 @@ dependencies {
     api(mnData.micronaut.data.tx)
     api(mnSerde.micronaut.serde.api)
 
+    implementation(mnSerde.micronaut.serde.jackson)
     testImplementation(mnSerde.micronaut.serde.jackson)
 
     runtimeOnly(mn.snakeyaml)

--- a/tests/common-reactive/src/main/java/example/domain/IOwner.java
+++ b/tests/common-reactive/src/main/java/example/domain/IOwner.java
@@ -15,6 +15,9 @@
  */
 package example.domain;
 
+import io.micronaut.serde.annotation.Serdeable;
+
+@Serdeable
 public interface IOwner {
 
     void setId(Long id);

--- a/tests/common/build.gradle
+++ b/tests/common/build.gradle
@@ -8,6 +8,7 @@ dependencies {
     api(mnSerde.micronaut.serde.api)
     api(mnData.micronaut.data.tx)
 
+    implementation(mnSerde.micronaut.serde.jackson)
     testImplementation(mnSerde.micronaut.serde.jackson)
 
     runtimeOnly(mn.snakeyaml)

--- a/tests/common/src/main/java/example/domain/IOwner.java
+++ b/tests/common/src/main/java/example/domain/IOwner.java
@@ -15,6 +15,9 @@
  */
 package example.domain;
 
+import io.micronaut.serde.annotation.Serdeable;
+
+@Serdeable
 public interface IOwner {
 
     void setId(Long id);

--- a/tests/hibernate5/hibernate5-mariadb/src/test/groovy/example/sync/MariaDBAppSpec.groovy
+++ b/tests/hibernate5/hibernate5-mariadb/src/test/groovy/example/sync/MariaDBAppSpec.groovy
@@ -16,13 +16,12 @@
 package example.sync
 
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
-import io.micronaut.test.support.TestPropertyProvider
 import org.testcontainers.containers.JdbcDatabaseContainer
 import org.testcontainers.containers.MariaDBContainer
 import org.testcontainers.utility.DockerImageName
 
 @MicronautTest(packages = "example.domain")
-class MariaDBAppSpec extends AbstractHibernateAppSpec implements TestPropertyProvider {
+class MariaDBAppSpec extends AbstractHibernateAppSpec {
 
     @Override
     Class<?> getOwnerClass() {

--- a/tests/hibernate5/hibernate5-mariadb/src/test/groovy/example/sync/MariaDBAppSpec.groovy
+++ b/tests/hibernate5/hibernate5-mariadb/src/test/groovy/example/sync/MariaDBAppSpec.groovy
@@ -16,12 +16,13 @@
 package example.sync
 
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import io.micronaut.test.support.TestPropertyProvider
 import org.testcontainers.containers.JdbcDatabaseContainer
 import org.testcontainers.containers.MariaDBContainer
 import org.testcontainers.utility.DockerImageName
 
 @MicronautTest(packages = "example.domain")
-class MariaDBAppSpec extends AbstractHibernateAppSpec {
+class MariaDBAppSpec extends AbstractHibernateAppSpec implements TestPropertyProvider {
 
     @Override
     Class<?> getOwnerClass() {
@@ -35,7 +36,7 @@ class MariaDBAppSpec extends AbstractHibernateAppSpec {
 
     @Override
     JdbcDatabaseContainer getJdbcDatabaseContainer() {
-        return new MariaDBContainer(DockerImageName.parse("mariadb:10.9.3"))
+        return new MariaDBContainer(DockerImageName.parse("mariadb:10.8.2"))
     }
 
     @Override

--- a/tests/hibernate5/hibernate5-reactive-postgres/build.gradle
+++ b/tests/hibernate5/hibernate5-reactive-postgres/build.gradle
@@ -11,6 +11,7 @@ dependencies {
     implementation libs.managed.vertx.pg.client
 }
 
+// TODO: Enable the native image test when https://github.com/oracle/graal/issues/5510 gets fixed
 project.afterEvaluate {
     nativeCompile.enabled = false
     testNativeImage.enabled = false

--- a/tests/hibernate6/hibernate6-h2/build.gradle
+++ b/tests/hibernate6/hibernate6-h2/build.gradle
@@ -12,3 +12,9 @@ dependencies {
 configurations {
     all*.exclude module: "javassist"
 }
+
+// TODO: Enable native tests once javax.validation gets replaced with jakarta.validation which is required for hibernate6
+project.afterEvaluate {
+    nativeCompile.enabled = false
+    testNativeImage.enabled = false
+}

--- a/tests/hibernate6/hibernate6-mariadb/build.gradle
+++ b/tests/hibernate6/hibernate6-mariadb/build.gradle
@@ -13,3 +13,9 @@ dependencies {
 configurations {
     all*.exclude module: "javassist"
 }
+
+// TODO: Enable native tests once javax.validation gets replaced with jakarta.validation which is required for hibernate6
+project.afterEvaluate {
+    nativeCompile.enabled = false
+    testNativeImage.enabled = false
+}

--- a/tests/hibernate6/hibernate6-mariadb/src/test/groovy/example/sync/MariaDBAppSpec.groovy
+++ b/tests/hibernate6/hibernate6-mariadb/src/test/groovy/example/sync/MariaDBAppSpec.groovy
@@ -35,7 +35,7 @@ class MariaDBAppSpec extends AbstractHibernateAppSpec {
 
     @Override
     JdbcDatabaseContainer getJdbcDatabaseContainer() {
-        return new MariaDBContainer(DockerImageName.parse("mariadb:10.9.3"))
+        return new MariaDBContainer(DockerImageName.parse("mariadb:10.8.2"))
     }
 
     @Override

--- a/tests/hibernate6/hibernate6-mssql/build.gradle
+++ b/tests/hibernate6/hibernate6-mssql/build.gradle
@@ -24,3 +24,9 @@ graalvmNative {
         }
     }
 }
+
+// TODO: Enable native tests once javax.validation gets replaced with jakarta.validation which is required for hibernate6
+project.afterEvaluate {
+    nativeCompile.enabled = false
+    testNativeImage.enabled = false
+}

--- a/tests/hibernate6/hibernate6-mysql/build.gradle
+++ b/tests/hibernate6/hibernate6-mysql/build.gradle
@@ -13,3 +13,9 @@ dependencies {
 configurations {
     all*.exclude module: "javassist"
 }
+
+// TODO: Enable native tests once javax.validation gets replaced with jakarta.validation which is required for hibernate6
+project.afterEvaluate {
+    nativeCompile.enabled = false
+    testNativeImage.enabled = false
+}

--- a/tests/hibernate6/hibernate6-oracle/build.gradle
+++ b/tests/hibernate6/hibernate6-oracle/build.gradle
@@ -13,3 +13,9 @@ dependencies {
 configurations {
     all*.exclude module: "javassist"
 }
+
+// TODO: Enable native tests once javax.validation gets replaced with jakarta.validation which is required for hibernate6
+project.afterEvaluate {
+    nativeCompile.enabled = false
+    testNativeImage.enabled = false
+}

--- a/tests/hibernate6/hibernate6-postgres/build.gradle
+++ b/tests/hibernate6/hibernate6-postgres/build.gradle
@@ -13,3 +13,9 @@ dependencies {
 configurations {
     all*.exclude module: "javassist"
 }
+
+// TODO: Enable native tests once javax.validation gets replaced with jakarta.validation which is required for hibernate6
+project.afterEvaluate {
+    nativeCompile.enabled = false
+    testNativeImage.enabled = false
+}

--- a/tests/jooq-tests/jooq-r2dbc-postgres/build.gradle
+++ b/tests/jooq-tests/jooq-r2dbc-postgres/build.gradle
@@ -16,8 +16,3 @@ dependencies {
     testImplementation projects.tests.commonTests
     testImplementation libs.testcontainers.postgresql
 }
-
-tasks.withType(Test).configureEach {
-    // TODO: Re-enable this once we have a Micronaut Data snapshot for 4.0.0
-    enabled = false
-}

--- a/tests/jooq-tests/jooq-r2dbc-postgres/src/main/java/example/jooq/reactive/AbstractRepository.java
+++ b/tests/jooq-tests/jooq-r2dbc-postgres/src/main/java/example/jooq/reactive/AbstractRepository.java
@@ -40,7 +40,6 @@ public class AbstractRepository {
     }
 
     private ReactiveTransactionStatus<Connection> getTransactionStatus(ContextView contextView) {
-        // !!! This value is deprecated and will be removed soon replaced by ReactorReactiveTransactionOperations
-        return contextView.getOrDefault("io.micronaut.tx.STATUS", null);
+        return contextView.getOrDefault("io.micronaut.tx.status.r2dbc.default", null);
     }
 }

--- a/tests/jooq-tests/jooq-r2dbc-postgres/src/main/java/example/jooq/reactive/Owner.java
+++ b/tests/jooq-tests/jooq-r2dbc-postgres/src/main/java/example/jooq/reactive/Owner.java
@@ -1,14 +1,16 @@
 package example.jooq.reactive;
 
 import example.domain.IOwner;
+import io.micronaut.serde.annotation.Serdeable;
 
+@Serdeable
 public class Owner implements IOwner {
 
     private Long id;
     private String name;
     private int age;
 
-    public Owner() {
+    Owner() {
     }
 
     public Owner(Long id, String name, int age) {

--- a/tests/jooq-tests/jooq-r2dbc-postgres/src/main/java/example/jooq/reactive/Pet.java
+++ b/tests/jooq-tests/jooq-r2dbc-postgres/src/main/java/example/jooq/reactive/Pet.java
@@ -2,7 +2,10 @@ package example.jooq.reactive;
 
 import example.domain.IOwner;
 import example.domain.IPet;
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.serde.annotation.Serdeable;
 
+@Serdeable
 public class Pet implements IPet {
 
     private Long id;
@@ -10,10 +13,10 @@ public class Pet implements IPet {
     private PetType type;
     private Owner owner;
 
-    public Pet() {
+    Pet() {
     }
 
-    public Pet(Long id, String name, PetType type, Owner owner) {
+    public Pet(Long id, String name, @Nullable PetType type, Owner owner) {
         this.id = id;
         this.name = name;
         this.type = type;


### PR DESCRIPTION
Changes:

- Enabled native tests
- Removed duplicate `org.hibernate.event.spi.PersistEventListener[]` entry from `HibernateSubstitutions.java`
- Fixed issues caused by removal of `ch.qos.logback` and `org.slf4j` from `--initialize-at-build-time` in a [core module](https://github.com/micronaut-projects/micronaut-core/commit/3cbbcce87b757ae55a327b7dff18e4a4879e64aa)
- Fixed issues caused by mariadb client upgrade from 2.7.6 to 3.1.1
- Disabled hibernate6 native tests until `javax.validation` gets replaced with `jakarta.validation` which is required for hibernate6
- Changed mariadb version used for testing from `10.9.3` to `10.8.2` because `10.9.3` failed to start docker container