### PR TITLE
Require Java 11 for micronaut-jooq and patch update jooq

### DIFF
--- a/.github/workflows/graalvm.yml
+++ b/.github/workflows/graalvm.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         java: ['11', '17']
-        graalvm: ['latest', 'dev']
+        graalvm: ['latest']
     steps:
        # https://github.com/actions/virtual-environments/issues/709
       - name: Free disk space

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,7 +9,7 @@ micronaut-gradle-plugin = "3.6.0"
 # Frameworks
 
 managed-vertx = "4.3.3"
-managed-jooq = "3.15.11"
+managed-jooq = "3.15.12"
 managed-hibernate = "5.6.11.Final"
 managed-hibernate-reactive = "1.1.7.Final"
 managed-jasync = "2.0.8"

--- a/jooq/build.gradle
+++ b/jooq/build.gradle
@@ -2,6 +2,11 @@ plugins {
     id 'io.micronaut.build.internal.sql-module'
 }
 
+micronautBuild {
+    sourceCompatibility = "11"
+    targetCompatibility = "11"
+}
+
 sourceSets {
     txTest {
         compileClasspath += main.output

--- a/src/main/docs/guide/jooq.adoc
+++ b/src/main/docs/guide/jooq.adoc
@@ -1,5 +1,7 @@
 Micronaut supports automatically configuring http://www.jooq.org/[jOOQ] library for fluent, typesafe SQL query construction.
 
+NOTE: Since v4.5.0 of this library, the micronaut-jooq module requires Java 11 or higher.
+
 To configure jOOQ library you should first add `jooq` module to your classpath:
 
 dependency:micronaut-jooq[groupId="io.micronaut.sql"]


### PR DESCRIPTION
In 4.5.0 we upgraded Jooq to get R2DBC support.

As Jooq 3.15.x requires Java 11, the Jooq module was marked as Java 11 only (in v4.5.x)

This restriction was removed in 4.6.x, however jOOQ still required Java 11.

Normally, we would downgrade jOOQ to maintain Java 8 support, however R2DBC support only exists in 3.15+ so we cannot do this.

This PR:

- re-introduces the java 11 compile target for the jOOQ module
- adds a note to the documentation to say that the jooq module requires Java 11+
- Updates jOOQ to the latest patch release of 3.15 (at time of writing)

Closes #821

We should merge this up for Micronaut 3.8.7