### PR TITLE
Added metadata for tomcat-jdbc connection pool

### DIFF
--- a/jdbc-tomcat/src/main/resources/META-INF/native-image/io.micronaut.sql/jdbc-tomcat-graal/proxy-config.json
+++ b/jdbc-tomcat/src/main/resources/META-INF/native-image/io.micronaut.sql/jdbc-tomcat-graal/proxy-config.json
@@ -1,0 +1,35 @@
+[
+    {
+        "condition": {
+            "typeReachable": "org.apache.tomcat.jdbc.pool.interceptor.AbstractCreateStatementInterceptor"
+        },
+        "interfaces": [
+            "java.sql.CallableStatement"
+        ]
+    },
+    {
+        "condition": {
+            "typeReachable": "org.apache.tomcat.jdbc.pool.ConnectionPool"
+        },
+        "interfaces": [
+            "java.sql.Connection",
+            "javax.sql.PooledConnection"
+        ]
+    },
+    {
+        "condition": {
+            "typeReachable": "org.apache.tomcat.jdbc.pool.interceptor.AbstractCreateStatementInterceptor"
+        },
+        "interfaces": [
+            "java.sql.PreparedStatement"
+        ]
+    },
+    {
+        "condition": {
+            "typeReachable": "org.apache.tomcat.jdbc.pool.interceptor.AbstractCreateStatementInterceptor"
+        },
+        "interfaces": [
+            "java.sql.Statement"
+        ]
+    }
+]

--- a/tests/hibernate6/hibernate6-h2/build.gradle
+++ b/tests/hibernate6/hibernate6-h2/build.gradle
@@ -6,6 +6,8 @@ dependencies {
     implementation projects.micronautTests.micronautHibernate6.micronautHibernate6SyncCommon
     testImplementation projects.micronautTests.micronautCommonTests
 
+    runtimeOnly projects.micronautJdbcHikari
+
     runtimeOnly libs.managed.h2
 }
 

--- a/tests/hibernate6/hibernate6-mariadb/build.gradle
+++ b/tests/hibernate6/hibernate6-mariadb/build.gradle
@@ -6,6 +6,8 @@ dependencies {
     implementation projects.micronautTests.micronautHibernate6.micronautHibernate6SyncCommon
     testImplementation projects.micronautTests.micronautCommonTests
 
+    runtimeOnly projects.micronautJdbcHikari
+
     runtimeOnly libs.managed.mariadb.java.client
 }
 

--- a/tests/hibernate6/hibernate6-mssql/build.gradle
+++ b/tests/hibernate6/hibernate6-mssql/build.gradle
@@ -6,6 +6,8 @@ dependencies {
     implementation projects.micronautTests.micronautHibernate6.micronautHibernate6SyncCommon
     testImplementation projects.micronautTests.micronautCommonTests
 
+    runtimeOnly projects.micronautJdbcHikari
+
     runtimeOnly libs.managed.mssql.jdbc
 }
 

--- a/tests/hibernate6/hibernate6-mysql/build.gradle
+++ b/tests/hibernate6/hibernate6-mysql/build.gradle
@@ -6,6 +6,8 @@ dependencies {
     implementation projects.micronautTests.micronautHibernate6.micronautHibernate6SyncCommon
     testImplementation projects.micronautTests.micronautCommonTests
 
+    runtimeOnly projects.micronautJdbcTomcat
+
     runtimeOnly libs.managed.mysql.connector.java
 }
 

--- a/tests/hibernate6/hibernate6-oracle/build.gradle
+++ b/tests/hibernate6/hibernate6-oracle/build.gradle
@@ -6,6 +6,8 @@ dependencies {
     implementation projects.micronautTests.micronautHibernate6.micronautHibernate6SyncCommon
     testImplementation projects.micronautTests.micronautCommonTests
 
+    runtimeOnly projects.micronautJdbcTomcat
+
     runtimeOnly libs.managed.ojdbc11
 }
 

--- a/tests/hibernate6/hibernate6-postgres/build.gradle
+++ b/tests/hibernate6/hibernate6-postgres/build.gradle
@@ -6,6 +6,8 @@ dependencies {
     implementation projects.micronautTests.micronautHibernate6.micronautHibernate6SyncCommon
     testImplementation projects.micronautTests.micronautCommonTests
 
+    runtimeOnly projects.micronautJdbcTomcat
+
     runtimeOnly libs.managed.postgresql
 }
 

--- a/tests/hibernate6/hibernate6-sync-common/build.gradle
+++ b/tests/hibernate6/hibernate6-sync-common/build.gradle
@@ -5,7 +5,6 @@ plugins {
 dependencies {
     implementation projects.micronautTests.micronautCommonSync
     implementation projects.micronautHibernateJpa
-    runtimeOnly projects.micronautJdbcHikari
 
     runtimeOnly(mn.snakeyaml)
 }


### PR DESCRIPTION
Added temporary metadata for tomcat-jdbc connection pool until those metadata get reviewed, approved and released in the shared metadata repository. Also modified a few native tests to use tomcat-jdbc connection pool.