### PR TITLE
Addional metadata for tomcat-jdbc connection pool

### DIFF
--- a/jdbc-tomcat/src/main/resources/META-INF/native-image/io.micronaut.sql/jdbc-tomcat-graal/reflect-config.json
+++ b/jdbc-tomcat/src/main/resources/META-INF/native-image/io.micronaut.sql/jdbc-tomcat-graal/reflect-config.json
@@ -1,0 +1,102 @@
+[
+    {
+        "condition": {
+            "typeReachable": "org.apache.tomcat.jdbc.pool.PooledConnection"
+        },
+        "name": "com.microsoft.sqlserver.jdbc.SQLServerDriver"
+    },
+    {
+        "condition": {
+            "typeReachable": "org.apache.tomcat.jdbc.pool.PooledConnection"
+        },
+        "name": "com.microsoft.sqlserver.jdbc.SQLServerDriver",
+        "methods": [
+            {
+                "name": "<init>",
+                "parameterTypes": [
+
+                ]
+            }
+        ]
+    },
+    {
+        "condition": {
+            "typeReachable": "org.apache.tomcat.jdbc.pool.PooledConnection"
+        },
+        "name": "com.mysql.cj.jdbc.Driver"
+    },
+    {
+        "condition": {
+            "typeReachable": "org.apache.tomcat.jdbc.pool.PooledConnection"
+        },
+        "name": "com.mysql.cj.jdbc.Driver",
+        "methods": [
+            {
+                "name": "<init>",
+                "parameterTypes": [
+
+                ]
+            }
+        ]
+    },
+    {
+        "condition": {
+            "typeReachable": "org.apache.tomcat.jdbc.pool.PooledConnection"
+        },
+        "name": "oracle.jdbc.driver.OracleDriver"
+    },
+    {
+        "condition": {
+            "typeReachable": "org.apache.tomcat.jdbc.pool.PooledConnection"
+        },
+        "name": "oracle.jdbc.driver.OracleDriver",
+        "methods": [
+            {
+                "name": "<init>",
+                "parameterTypes": [
+
+                ]
+            }
+        ]
+    },
+    {
+        "condition": {
+            "typeReachable": "org.apache.tomcat.jdbc.pool.PooledConnection"
+        },
+        "name": "org.mariadb.jdbc.Driver"
+    },
+    {
+        "condition": {
+            "typeReachable": "org.apache.tomcat.jdbc.pool.PooledConnection"
+        },
+        "name": "org.mariadb.jdbc.Driver",
+        "methods": [
+            {
+                "name": "<init>",
+                "parameterTypes": [
+
+                ]
+            }
+        ]
+    },
+    {
+        "condition": {
+            "typeReachable": "org.apache.tomcat.jdbc.pool.PooledConnection"
+        },
+        "name": "org.postgresql.Driver"
+    },
+    {
+        "condition": {
+            "typeReachable": "org.apache.tomcat.jdbc.pool.PooledConnection"
+        },
+        "name": "org.postgresql.Driver",
+        "methods": [
+            {
+                "name": "<init>",
+                "parameterTypes": [
+
+                ]
+            }
+        ]
+    }
+]


### PR DESCRIPTION
Added more temporary metadata for tomcat-jdbc connection pool until those metadata get reviewed, approved and released in the shared metadata repository.