### PR TITLE
Fix oracle driver issue in native tests

### DIFF
--- a/tests/hibernate6/hibernate6-oracle/src/test/java/example/hibernate6/sync/OracleDBApp.java
+++ b/tests/hibernate6/hibernate6-oracle/src/test/java/example/hibernate6/sync/OracleDBApp.java
@@ -21,6 +21,7 @@ import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
 
 @MicronautTest
 @Property(name = "datasources.default.db-type", value = "oracle")
+@Property(name = "datasources.default.driverClassName", value = "oracle.jdbc.OracleDriver")
 @Property(name = "jpa.default.properties.hibernate.dialect", value = "org.hibernate.dialect.OracleDialect")
 @Property(name = "test-resources.containers.oracle.image-name", value = "gvenzl/oracle-xe:slim")
 public class OracleDBApp extends AbstractApp {


### PR DESCRIPTION
Explicitly set driverClassName to `oracle.jdbc.OracleDriver` to avoid usage of `oracle.jdbc.driver.OracleDriver` which comes with new version of testcontainers (1.18.0). The `oracle.jdbc.driver.OracleDriver` has been deprecated and requires additional native image metadata.