### PR TITLE
Check if Metrics are enabled prior to getting the MeterRegistry bean

### DIFF
--- a/jdbc-hikari/src/main/java/io/micronaut/configuration/jdbc/hikari/DatasourceFactory.java
+++ b/jdbc-hikari/src/main/java/io/micronaut/configuration/jdbc/hikari/DatasourceFactory.java
@@ -71,12 +71,12 @@ public class DatasourceFactory implements AutoCloseable {
 
     private void addMeterRegistry(HikariUrlDataSource ds) {
         try {
-            MeterRegistry meterRegistry = getMeterRegistry();
-            if (ds != null && meterRegistry != null &&
-                    this.applicationContext
-                            .getProperty(MICRONAUT_METRICS_BINDERS + ".jdbc.enabled",
-                                    boolean.class).orElse(true)) {
-                ds.setMetricRegistry(meterRegistry);
+            Boolean metricsEnabled = this.applicationContext.getProperty(MICRONAUT_METRICS_BINDERS + ".jdbc.enabled", boolean.class).orElse(true);
+            if (ds != null && metricsEnabled) {
+                MeterRegistry meterRegistry = getMeterRegistry();
+                if (meterRegistry != null) {
+                    ds.setMetricRegistry(meterRegistry);
+                }
             }
         } catch (NoClassDefFoundError ignore) {
             LOG.debug("Could not wire metrics to HikariCP as there is no class of type MeterRegistry on the classpath, io.micronaut.configuration:micrometer-core library missing.");

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,6 +1,6 @@
 pluginManagement {
     plugins {
-        id 'io.micronaut.build.shared.settings' version '5.4.6'
+        id 'io.micronaut.build.shared.settings' version '5.4.7'
     }
     repositories {
         gradlePluginPortal()

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,6 +1,6 @@
 pluginManagement {
     plugins {
-        id 'io.micronaut.build.shared.settings' version '5.4.7'
+        id 'io.micronaut.build.shared.settings' version '5.4.9'
     }
     repositories {
         gradlePluginPortal()


### PR DESCRIPTION
We had an issue of a circular loop when trying to load a DataSource by name from the BeanContext.

Disabling the metrics made no difference, as the Bean was retrieved prior to checking if it was enabled.

This change checks that metrics are enabled prior to attempting to get the metrics bean.