### PR TITLE
Use correct GAV in debug message

### DIFF
--- a/jdbc-hikari/src/main/java/io/micronaut/configuration/jdbc/hikari/DatasourceFactory.java
+++ b/jdbc-hikari/src/main/java/io/micronaut/configuration/jdbc/hikari/DatasourceFactory.java
@@ -79,7 +79,7 @@ public class DatasourceFactory implements AutoCloseable {
                 ds.setMetricRegistry(meterRegistry);
             }
         } catch (NoClassDefFoundError ignore) {
-            LOG.debug("Could not wire metrics to HikariCP as there is no class of type MeterRegistry on the classpath, io.micronaut.configuration:micrometer-core library missing.");
+            LOG.debug("Could not wire metrics to HikariCP as there is no class of type MeterRegistry on the classpath, io.micronaut.micrometer:micrometer-core library missing.");
         }
     }
 


### PR DESCRIPTION
Fix group ID referenced in log message to match actual name of dependency.