### PR TITLE
Adding OnGres SCRAM client to the micronaut-sql dependencies catalog

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -53,7 +53,7 @@ managed-h2 = "2.1.214"
 # Other
 
 sfm-reflect = "8.2.3"
-# Needed for vertx pg client
+# Needed for vertx pg client and micronaut-data hibernate reactive
 managed-ongres-scram = "2.1"
 
 # Logback

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -53,6 +53,8 @@ managed-h2 = "2.1.214"
 # Other
 
 sfm-reflect = "8.2.3"
+# Needed for vertx pg client
+managed-ongres-scram = "2.1"
 
 # Logback
 
@@ -148,6 +150,7 @@ managed-jakarta-transaction-api = { module = "jakarta.transaction:jakarta.transa
 # Others
 
 sfm-reflect = { module = "org.simpleflatmapper:sfm-reflect", version.ref = "sfm-reflect" }
+managed-ongres-scram-client = { module = "com.ongres.scram:client", version.ref = "managed-ongres-scram" }
 
 # Testcontainers
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -12,7 +12,6 @@ plugins {
 enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
 
 micronautBuild {
-    importMicronautCatalog("micronaut-logging")
     useStandardizedProjectNames = true
     importMicronautCatalog()
     importMicronautCatalog("micronaut-cache")

--- a/tests/hibernate6/hibernate6-reactive-postgres/build.gradle
+++ b/tests/hibernate6/hibernate6-reactive-postgres/build.gradle
@@ -6,7 +6,6 @@ dependencies {
     implementation projects.micronautTests.micronautHibernate6.micronautHibernate6ReactiveCommon
     testImplementation projects.micronautTests.micronautCommonTests
 
-//    implementation projects.vertxPgClient
     implementation libs.managed.vertx.pg.client
 }
 


### PR DESCRIPTION
This is needed in micronaut-data for hibernate reactive tests so we declare it here as it belongs better. It may be needed in this project as well at some point.
Tried adding as `implementation` dependency but still need to add `runtimeOnly` in micronaut-data so did not add explicit dependency here.