### PR TITLE
add hint about R2DBC configuration

### DIFF
--- a/src/main/docs/guide/jooq/jooq-dialect.adoc
+++ b/src/main/docs/guide/jooq/jooq-dialect.adoc
@@ -9,4 +9,10 @@ jooq:
     datasources:
         default:
             sql-dialect: 'POSTGRES'
+
+# Or if you're using R2DBC, you should use `r2dbc-datasources` like this:
+jooq:
+    r2dbc-datasources:
+        default:
+            sql-dialect: 'POSTGRES'
 ----


### PR DESCRIPTION
There is no hint about this, only browsing the actual source code of micronaut-sql gave me the solution, so it could be helpful for others too.