### PR TITLE
Hack fix for micronaut-sql javadoc task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,3 +14,9 @@ if (System.getenv("SONAR_TOKEN") != null) {
         }
     }
 }
+
+javadoc {
+    // jooqapi=https://www.jooq.org/javadoc/latest from gradle.properties gets into javadoc options.links
+    // but it is throwing certificate exception and fails project from building
+    options.links.remove(jooqapi)
+}


### PR DESCRIPTION
I faced strange error when merging to master last week. [Javadoc task failed](https://github.com/micronaut-projects/micronaut-sql/actions/runs/6982754515/job/19002897068) due to this reason:

```
> Task :javadoc
error: Error fetching URL: https://www.jooq.org/javadoc/latest/ (javax.net.ssl.SSLHandshakeException: PKIX path building failed: sun.security.provider.certpath.SunCertPathBuilderException: unable to find valid certification path to requested target)
1 error
```

We have this property in gradle.properties
```
jooqapi=https://www.jooq.org/javadoc/latest
```
that is being used in apidocs to generate links. But, `JavadocAggregatorPlugin` in micronaut-build is getting all gradle.properties and pushes those starting with `http` into `options.links`. Then seems like javadoc tasks is checking all links, and for some reason this jooq link fails to resolve (certificate error, noticed certificate is renewed on Nov 20th 2023.).
So, this hack fixes the issue, or else we cannot publish changes in micronaut-sql. I hope you have some better fix, but until that is found we could use this. This link is not being used in javadocs in micronaut-sql so it's safe to skip it this way.