### PR TITLE
Revert ojdbc version 23.3.0.23.09 back to 21.11.0.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -31,7 +31,7 @@ managed-jdbi = "3.44.1"
 
 # JDBC Drivers
 
-managed-ojdbc = "23.3.0.23.09"
+managed-ojdbc = "21.11.0.0"
 managed-ojdbcdms = "21.11.0.0"
 managed-postgres-driver = "42.7.1"
 managed-mariadb-driver = "3.3.2"

--- a/jdbc-ucp/src/test/groovy/io/micronaut/configuration/jdbc/ucp/DatasourceConfigurationSpec.groovy
+++ b/jdbc-ucp/src/test/groovy/io/micronaut/configuration/jdbc/ucp/DatasourceConfigurationSpec.groovy
@@ -24,8 +24,6 @@ import oracle.ucp.jdbc.PoolDataSource
 import spock.lang.Specification
 
 import javax.sql.DataSource
-import java.time.Duration
-import java.time.temporal.ChronoUnit
 
 class DatasourceConfigurationSpec extends Specification {
 
@@ -115,7 +113,7 @@ class DatasourceConfigurationSpec extends Specification {
                         'datasources.default.maxPoolSize'              : 20,
                         'datasources.default.timeoutCheckInterval'     : 5,
                         'datasources.default.inactiveConnectionTimeout': 10,
-                        'datasources.default.connectionWaitDuration'   : '10s',
+                        'datasources.default.connectionWaitTimeout'    : 10,
                         'datasources.default.loginTimeout'             : 20,
                 ]
         ))
@@ -135,7 +133,7 @@ class DatasourceConfigurationSpec extends Specification {
         dataSource.getMaxPoolSize() == 20
         dataSource.getTimeoutCheckInterval() == 5
         dataSource.getInactiveConnectionTimeout() == 10
-        dataSource.getConnectionWaitDuration() == Duration.of(10, ChronoUnit.SECONDS)
+        dataSource.getConnectionWaitTimeout() == 10
         dataSource.getLoginTimeout() == 20
 
         cleanup:
@@ -196,7 +194,7 @@ class DatasourceConfigurationSpec extends Specification {
                         'datasources.default.maxPoolSize'              : 20,
                         'datasources.default.timeoutCheckInterval'     : 5,
                         'datasources.default.inactiveConnectionTimeout': 10,
-                        'datasources.default.connectionWaitDuration'   : '10s',
+                        'datasources.default.connectionWaitTimeout'    : 10,
                         'datasources.default.loginTimeout'             : 20,
 
                         'datasources.person.initialPoolSize'           : 5,
@@ -204,7 +202,7 @@ class DatasourceConfigurationSpec extends Specification {
                         'datasources.person.maxPoolSize'               : 20,
                         'datasources.person.timeoutCheckInterval'      : 5,
                         'datasources.person.inactiveConnectionTimeout' : 10,
-                        'datasources.person.connectionWaitDuration'    : '10s',
+                        'datasources.person.connectionWaitTimeout'     : 10,
                         'datasources.person.loginTimeout'              : 20,
                 ]
         ))
@@ -224,7 +222,7 @@ class DatasourceConfigurationSpec extends Specification {
         dataSource.getMaxPoolSize() == 20
         dataSource.getTimeoutCheckInterval() == 5
         dataSource.getInactiveConnectionTimeout() == 10
-        dataSource.getConnectionWaitDuration() == Duration.of(10, ChronoUnit.SECONDS)
+        dataSource.getConnectionWaitTimeout() == 10
         dataSource.getLoginTimeout() == 20
 
         when:
@@ -236,7 +234,7 @@ class DatasourceConfigurationSpec extends Specification {
         dataSource.getMaxPoolSize() == 20
         dataSource.getTimeoutCheckInterval() == 5
         dataSource.getInactiveConnectionTimeout() == 10
-        dataSource.getConnectionWaitDuration() == Duration.of(10, ChronoUnit.SECONDS)
+        dataSource.getConnectionWaitTimeout() == 10
         dataSource.getLoginTimeout() == 20
 
         cleanup:
@@ -255,7 +253,7 @@ class DatasourceConfigurationSpec extends Specification {
                         'datasources.default.maxPoolSize'              : 20,
                         'datasources.default.timeoutCheckInterval'     : 5,
                         'datasources.default.inactiveConnectionTimeout': 10,
-                        'datasources.default.connectionWaitDuration'   : '10s',
+                        'datasources.default.connectionWaitTimeout'    : 10,
                         'datasources.default.loginTimeout'             : 20,
 
                         'datasources.person.initialPoolSize'           : 5,
@@ -263,7 +261,7 @@ class DatasourceConfigurationSpec extends Specification {
                         'datasources.person.maxPoolSize'               : 20,
                         'datasources.person.timeoutCheckInterval'      : 5,
                         'datasources.person.inactiveConnectionTimeout' : 10,
-                        'datasources.person.connectionWaitDuration'    : '10s',
+                        'datasources.person.connectionWaitTimeout'     : 10,
                         'datasources.person.loginTimeout'              : 20,
                 ]
         ))
@@ -292,7 +290,7 @@ class DatasourceConfigurationSpec extends Specification {
                         'datasources.default.maxPoolSize'              : 20,
                         'datasources.default.timeoutCheckInterval'     : 5,
                         'datasources.default.inactiveConnectionTimeout': 10,
-                        'datasources.default.connectionWaitDuration'   : '10s',
+                        'datasources.default.connectionWaitTimeout'    : 10,
                         'datasources.default.loginTimeout'             : 20,
 
                         'datasources.person.initialPoolSize'           : 5,
@@ -300,7 +298,7 @@ class DatasourceConfigurationSpec extends Specification {
                         'datasources.person.maxPoolSize'               : 20,
                         'datasources.person.timeoutCheckInterval'      : 5,
                         'datasources.person.inactiveConnectionTimeout' : 10,
-                        'datasources.person.connectionWaitDuration'    : '10s',
+                        'datasources.person.connectionWaitTimeout'     : 10,
                         'datasources.person.loginTimeout'              : 20,
                 ]
         ))

--- a/settings.gradle
+++ b/settings.gradle
@@ -65,3 +65,5 @@ include 'tests:hibernate6:hibernate6-reactive-postgres'
 
 include 'tests:jooq-tests:jooq-jdbc-postgres'
 include 'tests:jooq-tests:jooq-r2dbc-postgres'
+
+include 'tests:jdbc-ucp-tests:jdbc-ucp-oracle'

--- a/tests/jdbc-ucp-tests/jdbc-ucp-oracle/build.gradle
+++ b/tests/jdbc-ucp-tests/jdbc-ucp-oracle/build.gradle
@@ -1,0 +1,20 @@
+plugins {
+    id 'io.micronaut.build.internal.test-application'
+}
+
+dependencies {
+    implementation projects.micronautJdbcUcp
+    implementation projects.micronautTests.micronautCommonSync
+
+    runtimeOnly libs.managed.ojdbc11
+    runtimeOnly libs.managed.ucp
+
+    testImplementation projects.micronautTests.micronautCommonTests
+    testImplementation(mnData.micronaut.data.tx.jdbc)
+}
+
+micronaut {
+    testResources {
+        additionalModules.add(JDBC_ORACLE_XE)
+    }
+}

--- a/tests/jdbc-ucp-tests/jdbc-ucp-oracle/src/main/java/example/jdbc/ucp/sync/Owner.java
+++ b/tests/jdbc-ucp-tests/jdbc-ucp-oracle/src/main/java/example/jdbc/ucp/sync/Owner.java
@@ -1,0 +1,52 @@
+package example.jdbc.ucp.sync;
+
+import example.domain.IOwner;
+import io.micronaut.core.annotation.Creator;
+import io.micronaut.serde.annotation.Serdeable;
+
+@Serdeable
+public class Owner implements IOwner {
+
+    private Long id;
+    private String name;
+    private int age;
+
+    Owner() {
+    }
+
+    @Creator
+    public Owner(Long id, String name, int age) {
+        this.id = id;
+        this.name = name;
+        this.age = age;
+    }
+
+    @Override
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public int getAge() {
+        return age;
+    }
+
+    @Override
+    public void setAge(int age) {
+        this.age = age;
+    }
+}

--- a/tests/jdbc-ucp-tests/jdbc-ucp-oracle/src/main/java/example/jdbc/ucp/sync/OwnerRepository.java
+++ b/tests/jdbc-ucp-tests/jdbc-ucp-oracle/src/main/java/example/jdbc/ucp/sync/OwnerRepository.java
@@ -1,0 +1,129 @@
+package example.jdbc.ucp.sync;
+
+import example.domain.IOwner;
+import example.sync.IOwnerRepository;
+import jakarta.annotation.PostConstruct;
+import jakarta.inject.Singleton;
+
+import jakarta.transaction.Transactional;
+
+import javax.sql.DataSource;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+
+@Singleton
+public class OwnerRepository implements IOwnerRepository {
+
+    private final DataSource dataSource;
+
+    public OwnerRepository(DataSource dataSource) {
+        this.dataSource = dataSource;
+    }
+
+    @PostConstruct
+    public void init() throws SQLException {
+        runInit();
+    }
+
+    @Transactional
+    public void runInit() throws SQLException {
+        PreparedStatement stmt = dataSource.getConnection().prepareStatement("""
+            CREATE TABLE owners (id INTEGER GENERATED ALWAYS AS IDENTITY NOT NULL,
+                                 name VARCHAR2(200) NOT NULL,
+                                 age INTEGER NOT NULL,
+                                 PRIMARY KEY (id))""");
+        stmt.executeUpdate();
+    }
+
+    @Override
+    public Owner create() {
+        return new Owner();
+    }
+
+    @Transactional(Transactional.TxType.MANDATORY)
+    @Override
+    public void save(IOwner owner) {
+        try {
+            PreparedStatement stmt = dataSource.getConnection().prepareStatement("INSERT INTO owners (name, age) VALUES (?, ?)",
+                new String[]{"id"});
+            stmt.setString(1, owner.getName());
+            stmt.setInt(2, owner.getAge());
+            stmt.executeUpdate();
+            ResultSet rs = stmt.getGeneratedKeys();
+            if (rs.next()) {
+                owner.setId(rs.getLong(1));
+            }
+        } catch (SQLException e) {
+            throw new RuntimeException("Failed to insert owner", e);
+        }
+    }
+
+    @Transactional(Transactional.TxType.MANDATORY)
+    @Override
+    public void delete(IOwner owner) {
+        try {
+            PreparedStatement stmt = dataSource.getConnection().prepareStatement("DELETE FROM owners WHERE id = ?");
+            stmt.setLong(1, owner.getId());
+            stmt.executeUpdate();
+        } catch (SQLException e) {
+            throw new RuntimeException("Failed to delete owner", e);
+        }
+    }
+
+    @Override
+    public IOwner findById(Long id) {
+        try {
+            PreparedStatement stmt = dataSource.getConnection().prepareStatement("SELECT * FROM owners WHERE id = ?");
+            stmt.setLong(1, id);
+            ResultSet rs = stmt.executeQuery();
+            if (rs.next()) {
+                return map(rs);
+            }
+            return null;
+        } catch (SQLException e) {
+            throw new RuntimeException("Failed to find owner by id", e);
+        }
+    }
+
+    @Override
+    public Collection<IOwner> findAll() {
+        try {
+            PreparedStatement stmt = dataSource.getConnection().prepareStatement("SELECT * FROM owners");
+            ResultSet rs = stmt.executeQuery();
+            List<IOwner> resultList = new ArrayList<>();
+            while (rs.next()) {
+                resultList.add(map(rs));
+            }
+            return resultList;
+        } catch (SQLException e) {
+            throw new RuntimeException("Failed to find all owners", e);
+        }
+    }
+
+    @Override
+    public Optional<IOwner> findByName(String name) {
+        try {
+            PreparedStatement stmt = dataSource.getConnection().prepareStatement("SELECT * FROM owners WHERE name = ?");
+            stmt.setString(1, name);
+            ResultSet rs = stmt.executeQuery();
+            if (rs.next()) {
+                return Optional.of(map(rs));
+            }
+            return Optional.empty();
+        } catch (SQLException e) {
+            throw new RuntimeException("Failed to find owner by name", e);
+        }
+    }
+
+    private IOwner map(ResultSet rs) throws SQLException {
+        return new Owner(rs.getLong("id"),
+                rs.getString("name"),
+                rs.getInt("age"));
+    }
+
+}

--- a/tests/jdbc-ucp-tests/jdbc-ucp-oracle/src/main/java/example/jdbc/ucp/sync/Pet.java
+++ b/tests/jdbc-ucp-tests/jdbc-ucp-oracle/src/main/java/example/jdbc/ucp/sync/Pet.java
@@ -1,0 +1,67 @@
+package example.jdbc.ucp.sync;
+
+import example.domain.IOwner;
+import example.domain.IPet;
+import io.micronaut.core.annotation.Creator;
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.serde.annotation.Serdeable;
+
+@Serdeable
+public class Pet implements IPet {
+
+    private Long id;
+    private String name;
+    private PetType type;
+    private Owner owner;
+
+    Pet() {
+    }
+
+    @Creator
+    public Pet(Long id, String name, @Nullable PetType type, Owner owner) {
+        this.id = id;
+        this.name = name;
+        this.type = type;
+        this.owner = owner;
+    }
+
+    @Override
+    public Long getId() {
+        return id;
+    }
+
+    @Override
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public Owner getOwner() {
+        return owner;
+    }
+
+    @Override
+    public void setOwner(IOwner owner) {
+        this.owner = (Owner) owner;
+    }
+
+    @Override
+    public PetType getType() {
+        return type;
+    }
+
+    @Override
+    public void setType(PetType type) {
+        this.type = type;
+    }
+}

--- a/tests/jdbc-ucp-tests/jdbc-ucp-oracle/src/main/java/example/jdbc/ucp/sync/PetRepository.java
+++ b/tests/jdbc-ucp-tests/jdbc-ucp-oracle/src/main/java/example/jdbc/ucp/sync/PetRepository.java
@@ -1,0 +1,118 @@
+package example.jdbc.ucp.sync;
+
+import example.domain.IPet;
+import example.sync.IPetRepository;
+import jakarta.annotation.PostConstruct;
+import jakarta.inject.Singleton;
+
+import jakarta.transaction.Transactional;
+
+import javax.sql.DataSource;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+
+@Singleton
+public class PetRepository implements IPetRepository {
+
+    private final DataSource dataSource;
+    private final OwnerRepository ownerRepository;
+
+    public PetRepository(DataSource dataSource, OwnerRepository ownerRepository) {
+        this.dataSource = dataSource;
+        this.ownerRepository = ownerRepository;
+    }
+
+    @PostConstruct
+    public void init() throws SQLException {
+        runInit();
+    }
+
+    @Transactional
+    public void runInit() throws SQLException {
+        PreparedStatement stmt = dataSource.getConnection().prepareStatement("""
+            CREATE TABLE pets (id INTEGER GENERATED ALWAYS AS IDENTITY NOT NULL,
+                               name VARCHAR2(200) NOT NULL,
+                               type VARCHAR2(200),
+                               owner INTEGER,
+                               PRIMARY KEY (id))""");
+        stmt.executeUpdate();
+    }
+
+    @Override
+    public IPet create() {
+        return new Pet();
+    }
+
+    @Transactional(Transactional.TxType.MANDATORY)
+    @Override
+    public void save(IPet pet) {
+        try {
+            PreparedStatement stmt = dataSource.getConnection().prepareStatement("INSERT INTO pets (name, type, owner) VALUES (?, ?, ?)",
+                new String[]{"id"});
+            stmt.setString(1, pet.getName());
+            stmt.setString(2, pet.getType() != null ? pet.getType().name() : null);
+            stmt.setLong(3, pet.getOwner().getId());
+            stmt.executeUpdate();
+            ResultSet rs = stmt.getGeneratedKeys();
+            if (rs.next()) {
+                pet.setId(rs.getLong(1));
+            }
+        } catch (SQLException e) {
+            throw new RuntimeException("Failed to insert pet", e);
+        }
+    }
+
+    @Transactional(Transactional.TxType.MANDATORY)
+    @Override
+    public void delete(IPet pet) {
+        try {
+            PreparedStatement stmt = dataSource.getConnection().prepareStatement("DELETE FROM pets WHERE id = ?");
+            stmt.setLong(1, pet.getId());
+            stmt.executeUpdate();
+        } catch (SQLException e) {
+            throw new RuntimeException("Failed to delete pet", e);
+        }
+    }
+
+    @Override
+    public Collection<IPet> findAll() {
+        try {
+            PreparedStatement stmt = dataSource.getConnection().prepareStatement("SELECT id, name, type, owner FROM pets");
+            ResultSet rs = stmt.executeQuery();
+            List<IPet> resultList = new ArrayList<>();
+            while (rs.next()) {
+                resultList.add(map(rs));
+            }
+            return resultList;
+        } catch (SQLException e) {
+            throw new RuntimeException("Failed to find all pets", e);
+        }
+    }
+
+    @Override
+    public Optional<IPet> findByName(String name) {
+        try {
+            PreparedStatement stmt = dataSource.getConnection().prepareStatement("SELECT id, name, type, owner FROM pets WHERE name = ?");
+            stmt.setString(1, name);
+            ResultSet rs = stmt.executeQuery();
+            if (rs.next()) {
+                return Optional.of(map(rs));
+            }
+            return Optional.empty();
+        } catch (SQLException e) {
+            throw new RuntimeException("Failed to find pet by name", e);
+        }
+    }
+
+    private IPet map(ResultSet rs) throws SQLException {
+        return new Pet(rs.getLong("id"),
+                rs.getString("name"),
+                Optional.ofNullable(rs.getString("type")).map(IPet.PetType::valueOf).orElse(null),
+                (Owner) ownerRepository.findById(rs.getLong("owner")));
+    }
+}

--- a/tests/jdbc-ucp-tests/jdbc-ucp-oracle/src/test/java/example/jdbc/ucp/sync/OracleApp.java
+++ b/tests/jdbc-ucp-tests/jdbc-ucp-oracle/src/test/java/example/jdbc/ucp/sync/OracleApp.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.jdbc.ucp.sync;
+
+import example.sync.AbstractApp;
+import io.micronaut.context.annotation.Property;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+
+@MicronautTest
+@Property(name = "datasources.default.db-type", value = "oracle")
+@Property(name = "datasources.default.connection-factory-class-name", value = "oracle.jdbc.pool.OracleDataSource")
+public class OracleApp extends AbstractApp {
+}
+

--- a/tests/jdbc-ucp-tests/jdbc-ucp-oracle/src/test/resources/logback.xml
+++ b/tests/jdbc-ucp-tests/jdbc-ucp-oracle/src/test/resources/logback.xml
@@ -1,0 +1,10 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+    <root level="info">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>


### PR DESCRIPTION
ucp 23.3.0.23.9 library doesn't work in a native image. Until fixed we should stick to 21.11.0.0.

I have added jdbc-ucp native test and then it will fail as renovate creates PR to upgrade to 23.x until the issue is fixed.

Cc: @msupic , @graemerocher 