### PR TITLE
Revert "fix: don’t leakage Micronaut Validation (#1267)"

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -68,7 +68,7 @@ sonar-gradle-plugin = "4.4.1.3373"
 micronaut-core = { module = 'io.micronaut:micronaut-core-bom', version.ref = 'micronaut' }
 
 # Platform catalogs
-micronaut-hibernate-validator = { module = "io.micronaut.beanvalidation:micronaut-hibernate-validator-bom", version.ref = "micronaut-hibernate-validator" }
+
 micronaut-cache = { module = "io.micronaut.cache:micronaut-cache-bom", version.ref = "micronaut-cache" }
 micronaut-data = { module = "io.micronaut.data:micronaut-data-bom", version.ref = "micronaut-data" }
 micronaut-micrometer = { module = "io.micronaut.micrometer:micronaut-micrometer-bom", version.ref = "micronaut-micrometer" }
@@ -79,6 +79,9 @@ micronaut-spring = { module = "io.micronaut.spring:micronaut-spring-bom", versio
 micronaut-test = { module = "io.micronaut.test:micronaut-test-bom", version.ref = "micronaut-test" }
 micronaut-test-resources = { module = "io.micronaut.testresources:micronaut-test-resources-bom", version.ref = "micronaut-test-resources" }
 micronaut-validation = { module = "io.micronaut.validation:micronaut-validation-bom", version.ref = "micronaut-validation" }
+
+# Switch to BOM and catalog import when there's a bom
+micronaut-hibernate-validator = { module = "io.micronaut.beanvalidation:micronaut-hibernate-validator", version.ref = "micronaut-hibernate-validator" }
 
 # Vertx
 

--- a/hibernate-jpa/build.gradle
+++ b/hibernate-jpa/build.gradle
@@ -7,7 +7,7 @@ dependencies {
 
     api(libs.managed.hibernate.core)
     api(libs.managed.jakarta.transaction.api)
-    compileOnly(mnValidation.validation) // jakarta.validation:jakarta.validation-api
+    api(mnValidation.micronaut.validation)
     compileOnly(mnData.micronaut.data.tx.hibernate)
     testImplementation(mnData.micronaut.data.tx.hibernate)
     api(mn.micronaut.aop)
@@ -27,8 +27,6 @@ dependencies {
     testImplementation(mnCache.micronaut.cache.core)
     testImplementation(mnMicrometer.micronaut.micrometer.core)
     testImplementation(libs.managed.hibernate.micrometer)
-
-    testImplementation(mnHibernateValidator.micronaut.hibernate.validator)
 
     testRuntimeOnly projects.micronautJdbcTomcat
     testRuntimeOnly(libs.managed.h2)

--- a/hibernate-reactive/build.gradle
+++ b/hibernate-reactive/build.gradle
@@ -26,5 +26,4 @@ dependencies {
     testImplementation(mnTestResources.testcontainers.postgres)
     testImplementation libs.managed.vertx.pg.client
     testImplementation(mnData.micronaut.data.tx.hibernate)
-    testImplementation(mnValidation.micronaut.validation)
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -23,7 +23,6 @@ micronautBuild {
     importMicronautCatalog("micronaut-spring")
     importMicronautCatalog("micronaut-test-resources")
     importMicronautCatalog("micronaut-validation")
-    importMicronautCatalog("micronaut-hibernate-validator")
 }
 
 rootProject.name = 'sql-parent'


### PR DESCRIPTION
This reverts commit 2dcf5740f19fe39d7fe72c896104fd1fbd3a8953 which was from https://github.com/micronaut-projects/micronaut-sql/pull/1267

When we stopped leaking micronaut-validation, we made a breaking change that broke the `@DateCreated` annotation in micronaut-data.

The events that are fired to in-fill these annotated values require a validatorfactory to fire, and so downstream users need to add one of `io.micronaut.validation:micronaut-validation` or `io.micronaut.beanvalidation:micronaut-hibernate-validator` to their builds...

We will revert this change for Micronaut 4.3.7 (v5.5.2 of this module), and revisit for Micronaut 5 where breakages can be expected and documented