### PR TITLE
Add com.oracle.database.jdbc:ucp11 to micronaut-sql

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -121,6 +121,7 @@ managed-hikaricp = { module = "com.zaxxer:HikariCP", version.ref = "managed-hika
 managed-commons-dbcp2 = { module = "org.apache.commons:commons-dbcp2", version.ref = "managed-commons-dbcp" }
 managed-tomcat-jdbc = { module = "org.apache.tomcat:tomcat-jdbc", version.ref = "managed-tomcat-jdbc" }
 managed-ucp = { module = "com.oracle.database.jdbc:ucp", version.ref = "managed-ojdbc" }
+managed-ucp11 = { module = "com.oracle.database.jdbc:ucp11", version.ref = "managed-ojdbc" }
 
 # UCP
 

--- a/jdbc-ucp/build.gradle
+++ b/jdbc-ucp/build.gradle
@@ -6,7 +6,7 @@ dependencies {
     api projects.micronautJdbc
     api(mn.micronaut.inject)
     api(mn.micronaut.context)
-    api(libs.managed.ucp)
+    api(libs.managed.ucp11)
     api(libs.managed.ojdbc11)
 
     testRuntimeOnly(libs.managed.h2)

--- a/tests/jdbc-ucp-tests/jdbc-ucp-oracle/build.gradle
+++ b/tests/jdbc-ucp-tests/jdbc-ucp-oracle/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     implementation projects.micronautTests.micronautCommonSync
 
     runtimeOnly libs.managed.ojdbc11
-    runtimeOnly libs.managed.ucp
+    runtimeOnly libs.managed.ucp11
 
     testImplementation projects.micronautTests.micronautCommonTests
     testImplementation(mnData.micronaut.data.tx.jdbc)


### PR DESCRIPTION
While we have ojdbc and ojdbc11, we have only `ucp` which is for JDK8 and could be useful to have `ucp11` for JDK11+