### PR TITLE
allow disabling JPA per datasource

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -45,7 +45,7 @@ jobs:
           fetch-depth: 0
 
       - name: "🔧 Setup GraalVM CE"
-        uses: graalvm/setup-graalvm@v1.2.3
+        uses: graalvm/setup-graalvm@v1.2.5
         with:
           distribution: 'graalvm'
           java-version: ${{ matrix.java }}

--- a/hibernate-jpa/src/main/java/io/micronaut/configuration/hibernate/jpa/JpaConfiguration.java
+++ b/hibernate-jpa/src/main/java/io/micronaut/configuration/hibernate/jpa/JpaConfiguration.java
@@ -49,7 +49,7 @@ import java.util.stream.Collectors;
  * @since 1.0
  */
 @EachProperty(value = JpaConfiguration.PREFIX, primary = JpaConfiguration.PRIMARY)
-public class JpaConfiguration {
+public class JpaConfiguration implements Toggleable {
     public static final String PREFIX = "jpa";
     public static final String PRIMARY = "default";
 
@@ -62,6 +62,7 @@ public class JpaConfiguration {
 
     private boolean compileTimeHibernateProxies;
     private boolean reactive;
+    private boolean enabled = true;
 
     /**
      * @param applicationContext The application context
@@ -95,6 +96,19 @@ public class JpaConfiguration {
         this.entityScanConfiguration = entityScanConfiguration != null ? entityScanConfiguration : new EntityScanConfiguration(applicationContext.getEnvironment());
         this.applicationContext = applicationContext;
         this.integrator = integrator;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return this.enabled;
+    }
+
+    /**
+     * Set whether the JPA integration for the datasource is enabled.
+     * @param enabled True if it is enabled
+     */
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
     }
 
     /**

--- a/hibernate-jpa/src/main/java/io/micronaut/configuration/hibernate/jpa/conf/SessionFactoryPerDataSourceFactory.java
+++ b/hibernate-jpa/src/main/java/io/micronaut/configuration/hibernate/jpa/conf/SessionFactoryPerDataSourceFactory.java
@@ -28,6 +28,7 @@ import io.micronaut.context.annotation.Parameter;
 import io.micronaut.context.annotation.Primary;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.context.env.Environment;
+import io.micronaut.context.exceptions.DisabledBeanException;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.annotation.TypeHint;
@@ -71,6 +72,8 @@ final class SessionFactoryPerDataSourceFactory extends AbstractHibernateFactory 
                                                           @Parameter String name) {
         if (jpaConfiguration == null) {
             jpaConfiguration = defaultJpaConfiguration.copy(name);
+        } else if (!jpaConfiguration.isEnabled()) {
+            throw new DisabledBeanException("JPA configuration for datasource [" + name + "] is disabled");
         }
         return super.buildHibernateStandardServiceRegistry(jpaConfiguration);
     }

--- a/hibernate-jpa/src/test/groovy/io/micronaut/configuration/hibernate/jpa/datasources/CurrentSessionWithMultipleDataSourcesSpec.groovy
+++ b/hibernate-jpa/src/test/groovy/io/micronaut/configuration/hibernate/jpa/datasources/CurrentSessionWithMultipleDataSourcesSpec.groovy
@@ -81,6 +81,23 @@ class CurrentSessionWithMultipleDataSourcesSpec extends Specification {
             context.close()
     }
 
+    void "test an application that defines multiple data sources - one disabled"() {
+        when:
+        def context = ApplicationContext.run(
+                'datasources.default.name': 'db1',
+                'datasources.db2.url': 'jdbc:h2:mem:db2;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE',
+                'datasources.abc.url': 'jdbc:h2:mem:db2;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE',
+                'jpa.db2.enabled': false,
+        )
+        then:
+        context.findBean(SessionFactory, Qualifiers.byName("default")).isPresent()
+        !context.findBean(SessionFactory, Qualifiers.byName("db2")).isPresent()
+        context.findBean(SessionFactory, Qualifiers.byName("abc")).isPresent()
+        !context.findBean(SessionFactory, Qualifiers.byName("unknown")).isPresent()
+        cleanup:
+        context.close()
+    }
+
     void "test parallel init of non-default SessionFactory with missing entities"() {
         when:
             def context = ApplicationContext.run(


### PR DESCRIPTION
Currently you can only disable JPA for all datasources, but you might want to use JPA for one datasource but not the other. This PR adds the ability to disable JPA for a particular datasource.