### PR TITLE
Added configuration option to control Borrowing Connections from UCP

### DIFF
--- a/jdbc-ucp/src/main/java/io/micronaut/configuration/jdbc/ucp/OracleUcpConfiguration.java
+++ b/jdbc-ucp/src/main/java/io/micronaut/configuration/jdbc/ucp/OracleUcpConfiguration.java
@@ -24,11 +24,13 @@ import static io.micronaut.configuration.jdbc.ucp.OracleUcpConfiguration.PREFIX;
 /**
  * Configuration properties for Oracle Universal Connection Pooling (UCP).
  *
- * @param destroyOnReload Flag indicating whether to destroy connections on reload
+ * @param destroyOnReload An indicating whether to destroy connections on reload
+ * @param createConnectionInBorrowThread An indicator telling whether connection pool should create connection in borrow thread.
+ *
  */
 @ConfigurationProperties(PREFIX)
 @Requires(property = PREFIX)
-public record OracleUcpConfiguration(@Nullable Boolean destroyOnReload) {
+public record OracleUcpConfiguration(@Nullable Boolean destroyOnReload, @Nullable Boolean createConnectionInBorrowThread) {
 
     /** Prefix used for configuration properties. */
     static final String PREFIX = "oracle.ucp";

--- a/jdbc-ucp/src/main/java/io/micronaut/configuration/jdbc/ucp/OracleUcpConfigurator.java
+++ b/jdbc-ucp/src/main/java/io/micronaut/configuration/jdbc/ucp/OracleUcpConfigurator.java
@@ -30,23 +30,32 @@ import oracle.ucp.jdbc.PoolDataSource;
 public class OracleUcpConfigurator {
 
     private static final String UCP_DESTROY_ON_RELOAD = "oracle.ucp.destroyOnReload";
+    private static final String UCP_CREATE_CONNECTION_IN_BORROW_THREAD = "oracle.ucp.createConnectionInBorrowThread";
 
     /**
-     * Initializes the Oracle UCP (Universal Connection Pooling) configuration.
+     * Initializes Oracle Universal Connection Pooling (UCP) configuration based on the provided
+     * {@link OracleUcpConfiguration}. This method sets system properties for UCP configuration
+     * if they are not already set.
      *
-     * <p>If the {@code oracle.ucp.destroyOnReload} system property is not set or is empty, this method
-     * sets it based on the value of the {@link OracleUcpConfiguration#destroyOnReload()} field.
-     * This property determines whether the connection pool should be destroyed when the application
-     * is reloaded.
+     * Specifically, it sets the following system properties:
+     * <ul>
+     *   <li>{@code oracle.ucp.destroyOnReload}: Controls whether to destroy connections on reload.
+     *   <li>{@code oracle.ucp.createConnectionInBorrowThread}: Controls whether the connection pool
+     *       should create connections in the borrow thread.
+     * </ul>
      *
-     * <p>This initialization helps prevent duplicate connection pool errors that may occur during
-     * application reloading.
+     * These properties are only set if the corresponding values in the provided configuration are not null
+     * and the system properties are not already set or are blank.
      *
-     * @param oracleUcpConfiguration The Oracle UCP configuration
+     * @param oracleUcpConfiguration the UCP configuration to apply, or null if no configuration is available
      */
     @PostConstruct
     public void initUcp(@Nullable OracleUcpConfiguration oracleUcpConfiguration) {
-        if (oracleUcpConfiguration != null && oracleUcpConfiguration.destroyOnReload() != null) {
+        if (oracleUcpConfiguration == null) {
+            return;
+        }
+
+        if (oracleUcpConfiguration.destroyOnReload() != null) {
             final String ucpDestroyOnReloadProperty = System.getProperty(UCP_DESTROY_ON_RELOAD);
             if (ucpDestroyOnReloadProperty == null || ucpDestroyOnReloadProperty.isBlank()) {
                 // This is to deal with a duplicate connection pool error of:
@@ -60,6 +69,18 @@ public class OracleUcpConfigurator {
                 System.setProperty(
                     UCP_DESTROY_ON_RELOAD,
                     String.valueOf(oracleUcpConfiguration.destroyOnReload()));
+            }
+        }
+
+        if (oracleUcpConfiguration.createConnectionInBorrowThread() != null) {
+            final String ucpCreateConnectionInBorrowThread = System.getProperty(UCP_CREATE_CONNECTION_IN_BORROW_THREAD);
+            if (ucpCreateConnectionInBorrowThread == null || ucpCreateConnectionInBorrowThread.isBlank()) {
+                // The current default behavior in UCP 23.x is to use background threads for creating connections,
+                // instead of the user threads, which results in enhanced efficiency. If required,
+                // it can be switched back to the old behavior by setting system property oracle.ucp.createConnectionInBorrowThread to true
+                System.setProperty(
+                    UCP_CREATE_CONNECTION_IN_BORROW_THREAD,
+                    String.valueOf(oracleUcpConfiguration.createConnectionInBorrowThread()));
             }
         }
     }

--- a/jdbc-ucp/src/test/groovy/io/micronaut/configuration/jdbc/ucp/DatasourceConfigurationSpec.groovy
+++ b/jdbc-ucp/src/test/groovy/io/micronaut/configuration/jdbc/ucp/DatasourceConfigurationSpec.groovy
@@ -392,7 +392,8 @@ class DatasourceConfigurationSpec extends Specification {
         ApplicationContext applicationContext = new DefaultApplicationContext("test")
         applicationContext.environment.addPropertySource(MapPropertySource.of(
                 'test',
-                ["datasources.default.data-source-properties": ["oracle.fan.enabled": true]]
+                ["datasources.default.data-source-properties": ["oracle.fan.enabled": true],
+                 "oracle.ucp.createConnectionInBorrowThread": "true"]
         ))
         applicationContext.start()
         DataSourceResolver dataSourceResolver =  applicationContext.findBean(DataSourceResolver).orElse(DataSourceResolver.DEFAULT)

--- a/jdbc-ucp/src/test/groovy/io/micronaut/configuration/jdbc/ucp/DatasourceConfigurationSpec.groovy
+++ b/jdbc-ucp/src/test/groovy/io/micronaut/configuration/jdbc/ucp/DatasourceConfigurationSpec.groovy
@@ -22,6 +22,7 @@ import io.micronaut.context.exceptions.NoSuchBeanException
 import io.micronaut.inject.qualifiers.Qualifiers
 import io.micronaut.jdbc.DataSourceResolver
 import oracle.ucp.jdbc.PoolDataSource
+import oracle.ucp.util.Util
 import spock.lang.Specification
 
 import javax.sql.DataSource
@@ -413,5 +414,8 @@ class DatasourceConfigurationSpec extends Specification {
 
         cleanup:
         applicationContext.close()
+        Util.createConnectionInBorrowThread()
+        System.setProperty("oracle.ucp.createConnectionInBorrowThread", "false")
+        !Util.createConnectionInBorrowThread()
     }
 }

--- a/src/main/docs/guide/jdbc/jdbc-connection-pools.adoc
+++ b/src/main/docs/guide/jdbc/jdbc-connection-pools.adoc
@@ -52,6 +52,10 @@ The Oracle UCP is managed by the link:https://docs.oracle.com/en/database/oracle
 
 In case when exception `Universal Connection Pool already exists in the Universal Connection Pool Manager` is thrown, there is `oracle.ucp.destroyOnReload` configuration that can be set to `true` to avoid this error. In that case, when creating new connection pool, if there is the one with the same name the old one will be destroyed first.
 
+There is also property `oracle.ucp.createConnectionInBorrowThread` that can control connection creation using background threads. The default configuration since UCP 23.x is that connections are created using background threads instead of user threads.
+Adding configuration `oracle.ucp.createConnectionInBorrowThread=true` will switch to the old behavior.
+More about it can be read here link:https://docs.oracle.com/en/database/oracle/oracle-database/23/jjucp/borrowing-ucp-connections.html[Borrowing Connections from UCP].
+
 For a list of other properties able to be configured, simply refer to the implementation that is being used. All setter methods are candidates for configuration.
 
 [cols="20%,80%"]

--- a/tests/hibernate6/hibernate6-mysql/src/test/java/example/hibernate6/sync/MySQLApp.java
+++ b/tests/hibernate6/hibernate6-mysql/src/test/java/example/hibernate6/sync/MySQLApp.java
@@ -22,5 +22,6 @@ import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
 @MicronautTest
 @Property(name = "datasources.default.db-type", value = "mysql")
 @Property(name = "jpa.default.properties.hibernate.dialect", value = "org.hibernate.dialect.MySQLDialect")
+@Property(name = "test-resources.containers.mysql.image-name", value = "mysql:8.4.5")
 public class MySQLApp extends AbstractApp {
 }

--- a/tests/hibernate6/hibernate6-reactive-mysql/src/test/java/example/hibernate6/reactive/MySQLApp.java
+++ b/tests/hibernate6/hibernate6-reactive-mysql/src/test/java/example/hibernate6/reactive/MySQLApp.java
@@ -22,5 +22,6 @@ import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
 @MicronautTest(transactional = false)
 @Property(name = "jpa.default.properties.hibernate.connection.db-type", value = "mysql")
 @Property(name = "jpa.default.reactive", value = "true")
+@Property(name = "test-resources.containers.mysql.image-name", value = "mysql:8.4.5")
 public class MySQLApp extends AbstractApp {
 }

--- a/tests/jdbc-tomcat-tests/jdbc-tomcat-mysql/src/test/java/example/jdbc/tomcat/sync/MySQLApp.java
+++ b/tests/jdbc-tomcat-tests/jdbc-tomcat-mysql/src/test/java/example/jdbc/tomcat/sync/MySQLApp.java
@@ -21,6 +21,7 @@ import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
 
 @MicronautTest
 @Property(name = "datasources.default.db-type", value = "mysql")
+@Property(name = "test-resources.containers.mysql.image-name", value = "mysql:8.4.5")
 public class MySQLApp extends AbstractApp {
 }
 

--- a/vertx-mysql-client/src/test/groovy/io/micronaut/configuration/vertx/mysql/client/MySQLClientSpec.groovy
+++ b/vertx-mysql-client/src/test/groovy/io/micronaut/configuration/vertx/mysql/client/MySQLClientSpec.groovy
@@ -33,7 +33,7 @@ import spock.lang.Specification
 
 class MySQLClientSpec extends Specification{
     // tag::mysql-testcontainer[]
-    @Shared @AutoCleanup MySQLContainer mysql = new MySQLContainer("mysql")
+    @Shared @AutoCleanup MySQLContainer mysql = new MySQLContainer("mysql:8.4.5")
 
     // end::mysql-testcontainer[]
 

--- a/vertx-mysql-client/src/test/groovy/io/micronaut/configuration/vertx/mysql/client/health/MySQLPoolHealthIndicatorSpec.groovy
+++ b/vertx-mysql-client/src/test/groovy/io/micronaut/configuration/vertx/mysql/client/health/MySQLPoolHealthIndicatorSpec.groovy
@@ -25,7 +25,7 @@ import spock.lang.Specification
 class MySQLPoolHealthIndicatorSpec extends Specification{
     void "test vertx-mysql-client health indicator"() {
         given:
-        MySQLContainer mysql = new MySQLContainer("mysql")
+        MySQLContainer mysql = new MySQLContainer("mysql:8.4.5")
         mysql.start()
         ApplicationContext applicationContext = ApplicationContext.run(
                 'vertx.mysql.client.port': mysql.getMappedPort(MySQLContainer.MYSQL_PORT),


### PR DESCRIPTION
This system property can be set by the users but this is convenient way to configure from Micronaut SQL configuration (like done in https://github.com/micronaut-projects/micronaut-sql/pull/1551 for `oracle.ucp.destroyOnReload`).