### PR TITLE
add jooq-bom to version catalog

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,7 +23,7 @@ micronaut-validation = "4.9.0"
 # Frameworks
 
 managed-vertx = "4.5.16"
-managed-jooq = "3.19.18"
+managed-jooq = "3.19.24"
 managed-hibernate = "6.6.23.Final"
 managed-hibernate-reactive = "2.4.8.Final"
 managed-jasync = "2.2.4"
@@ -95,6 +95,7 @@ managed-vertx-mssql-client = { module = "io.vertx:vertx-mssql-client", version.r
 managed-vertx-oracle-client = { module = "io.vertx:vertx-oracle-client", version.ref = "managed-vertx" }
 managed-vertx-rx-java2 = { module = "io.vertx:vertx-rx-java2", version.ref = "managed-vertx" }
 
+boms-jooq = { module = "org.jooq:jooq-bom", version.ref = "managed-jooq" }
 managed-jooq = { module = "org.jooq:jooq", version.ref = "managed-jooq" }
 
 # Hibernate


### PR DESCRIPTION
the current jooq version doesn't have a bom so it is upgraded to the closest version that does.

fixes #1613 