### PR TITLE
fix: use DataSourceResolver instead of type check

### DIFF
--- a/jdbc-ucp/src/main/java/io/micronaut/configuration/jdbc/ucp/ConnectionPoolManagerListener.java
+++ b/jdbc-ucp/src/main/java/io/micronaut/configuration/jdbc/ucp/ConnectionPoolManagerListener.java
@@ -20,8 +20,10 @@ import io.micronaut.context.event.BeanCreatedEvent;
 import io.micronaut.context.event.BeanCreatedEventListener;
 import io.micronaut.context.exceptions.ConfigurationException;
 import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.order.Ordered;
 import io.micronaut.core.util.StringUtils;
+import io.micronaut.jdbc.DataSourceResolver;
 import jakarta.inject.Singleton;
 import oracle.ucp.UniversalConnectionPoolAdapter;
 import oracle.ucp.UniversalConnectionPoolException;
@@ -31,6 +33,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.sql.DataSource;
+import java.sql.SQLException;
 
 
 /**
@@ -49,35 +52,52 @@ public class ConnectionPoolManagerListener implements BeanCreatedEventListener<D
 
     private final UniversalConnectionPoolManager connectionPoolManager;
 
-    public ConnectionPoolManagerListener(UniversalConnectionPoolManager connectionPoolManager) {
+    private final DataSourceResolver dataSourceResolver;
+
+    public ConnectionPoolManagerListener(UniversalConnectionPoolManager connectionPoolManager,
+                                         @Nullable DataSourceResolver dataSourceResolver) {
         this.connectionPoolManager = connectionPoolManager;
+        this.dataSourceResolver = dataSourceResolver == null ? DataSourceResolver.DEFAULT : dataSourceResolver;
     }
 
     @Override
     public DataSource onCreated(BeanCreatedEvent<DataSource> event) {
-        final DataSource dataSource = event.getBean();
-        if (dataSource instanceof PoolDataSource) {
-            final PoolDataSource poolDataSource = (PoolDataSource) dataSource;
-            final String poolName = poolDataSource.getConnectionPoolName();
+        final DataSource dataSource = dataSourceResolver.resolve(event.getBean());
+
+        if (dataSource instanceof PoolDataSource poolDataSource) {
+            createAndStartConnectionPool(poolDataSource);
+        } else {
             try {
-                if (LOG.isDebugEnabled()) {
-                    LOG.debug("Creating connection pool named: {}", poolName);
+                if (dataSource.isWrapperFor(PoolDataSource.class)) {
+                    createAndStartConnectionPool(dataSource.unwrap(PoolDataSource.class));
                 }
-                connectionPoolManager.createConnectionPool((UniversalConnectionPoolAdapter) dataSource);
-
-                if (LOG.isDebugEnabled()) {
-                    LOG.debug("Starting connection pool named: {}", poolName);
-                }
-                connectionPoolManager.startConnectionPool(poolName);
-                if (LOG.isInfoEnabled()) {
-                    LOG.info("Connection pool named: {} started", poolName);
-                }
-
-            } catch (UniversalConnectionPoolException e) {
-                throw new ConfigurationException(String.format("Failed to start connection pool named: %s", poolName), e);
+            } catch (SQLException e) {
+                throw new ConfigurationException(String.format("Failed to unwrap PoolDataSource from DataSource bean: %s", event.getBeanIdentifier()), e);
             }
         }
+
         return event.getBean();
+    }
+
+    private void createAndStartConnectionPool(PoolDataSource poolDataSource) {
+        final String poolName = poolDataSource.getConnectionPoolName();
+        try {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Creating connection pool named: {}", poolName);
+            }
+            connectionPoolManager.createConnectionPool((UniversalConnectionPoolAdapter) poolDataSource);
+
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Starting connection pool named: {}", poolName);
+            }
+            connectionPoolManager.startConnectionPool(poolName);
+            if (LOG.isInfoEnabled()) {
+                LOG.info("Connection pool named: {} started", poolName);
+            }
+
+        } catch (UniversalConnectionPoolException e) {
+            throw new ConfigurationException(String.format("Failed to start connection pool named: %s", poolName), e);
+        }
     }
 
     @Override

--- a/jdbc-ucp/src/test/groovy/io/micronaut/configuration/jdbc/ucp/ConnectionPoolManagerListenerSpec.groovy
+++ b/jdbc-ucp/src/test/groovy/io/micronaut/configuration/jdbc/ucp/ConnectionPoolManagerListenerSpec.groovy
@@ -1,0 +1,99 @@
+package io.micronaut.configuration.jdbc.ucp
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.DefaultApplicationContext
+import io.micronaut.context.env.MapPropertySource
+import io.micronaut.jdbc.DataSourceResolver
+import oracle.ucp.admin.UniversalConnectionPoolManager
+import oracle.ucp.jdbc.PoolDataSource
+import spock.lang.Specification
+
+import javax.sql.DataSource
+
+
+class ConnectionPoolManagerListenerSpec extends Specification {
+
+    void "test ucp-manager is enabled by default but does not manage any pools"() {
+        given:
+        var applicationContext = ApplicationContext.run("test")
+
+        expect:
+        !applicationContext.containsBean(DataSource)
+        applicationContext.containsBean(ConnectionPoolManagerListener)
+        applicationContext.containsBean(UniversalConnectionPoolManager)
+
+        when:
+        var poolManager = applicationContext.getBean(UniversalConnectionPoolManager)
+
+        then:
+        poolManager.getConnectionPoolNames() == new String[0]
+
+        cleanup:
+        applicationContext.close()
+    }
+
+    void "test ucp-manager is enabled by default and managing default pool"() {
+        given:
+        var applicationContext = ApplicationContext.run(
+                [
+                        "datasources.default.url": "jdbc:h2:mem:default;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE",
+                        "datasources.default.username": "sa",
+                        "datasources.default.password": ""],
+                "test")
+
+        expect:
+        applicationContext.containsBean(DataSource)
+        applicationContext.containsBean(ConnectionPoolManagerListener)
+        applicationContext.containsBean(UniversalConnectionPoolManager)
+
+        when:
+        var poolManager = applicationContext.getBean(UniversalConnectionPoolManager)
+
+        then:
+        poolManager.getConnectionPoolNames() == new String[]{"default"}
+
+        cleanup:
+        applicationContext.close()
+    }
+
+    void "test ucp-manager is enabled by default and managing default pool with custom name"() {
+        given:
+        var applicationContext = ApplicationContext.run(
+                [
+                        "datasources.default.url": "jdbc:h2:mem:default;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE",
+                        "datasources.default.username": "sa",
+                        "datasources.default.password": "",
+                        "datasources.default.connectionPoolName": "JDBC_UCP"],
+                "test")
+
+        expect:
+        applicationContext.containsBean(DataSource)
+        applicationContext.containsBean(ConnectionPoolManagerListener)
+        applicationContext.containsBean(UniversalConnectionPoolManager)
+
+        when:
+        var poolManager = applicationContext.getBean(UniversalConnectionPoolManager)
+
+        then:
+        poolManager.getConnectionPoolNames() == new String[]{"JDBC_UCP"}
+
+        cleanup:
+        applicationContext.close()
+    }
+
+    void "test disabled ucp-manager"() {
+        given:
+        var applicationContext = ApplicationContext.run(
+                [
+                        "ucp-manager.enabled": false,
+                ],
+                "test")
+
+        expect:
+        !applicationContext.containsBean(ConnectionPoolManagerListener)
+        !applicationContext.containsBean(UniversalConnectionPoolManager)
+
+        cleanup:
+        applicationContext.close()
+    }
+}

--- a/jdbc-ucp/src/test/groovy/io/micronaut/configuration/jdbc/ucp/test/DataSourceWrapperBeanEventListener.java
+++ b/jdbc-ucp/src/test/groovy/io/micronaut/configuration/jdbc/ucp/test/DataSourceWrapperBeanEventListener.java
@@ -1,0 +1,30 @@
+package io.micronaut.configuration.jdbc.ucp.test;
+
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.context.event.BeanCreatedEvent;
+import io.micronaut.context.event.BeanCreatedEventListener;
+import io.micronaut.core.order.Ordered;
+import jakarta.inject.Singleton;
+import org.springframework.jdbc.datasource.TransactionAwareDataSourceProxy;
+
+import javax.sql.DataSource;
+
+/**
+ * A {@link BeanCreatedEventListener} that wraps each {@link DataSource} in a {@link TransactionAwareDataSourceProxy}
+ * to create an example of a wrapped {@link DataSource} for test cases.
+ */
+@Singleton
+@Requires(env = "test")
+public class DataSourceWrapperBeanEventListener implements BeanCreatedEventListener<DataSource>, Ordered {
+
+    public DataSource onCreated(BeanCreatedEvent<DataSource> event) {
+        final DataSource dataSource = event.getBean();
+
+        return new TransactionAwareDataSourceProxy(dataSource);
+    }
+
+    public int getOrder() {
+        return Ordered.HIGHEST_PRECEDENCE;
+    }
+
+}

--- a/jdbc-ucp/src/test/groovy/io/micronaut/configuration/jdbc/ucp/test/TransactionAwareDataSourceProxyResolver.java
+++ b/jdbc-ucp/src/test/groovy/io/micronaut/configuration/jdbc/ucp/test/TransactionAwareDataSourceProxyResolver.java
@@ -1,0 +1,26 @@
+package io.micronaut.configuration.jdbc.ucp.test;
+
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.jdbc.DataSourceResolver;
+import jakarta.inject.Singleton;
+import org.springframework.jdbc.datasource.TransactionAwareDataSourceProxy;
+
+import javax.sql.DataSource;
+
+/**
+ * A {@link DataSourceResolver} that unwraps a {@link DataSource} from a {@link TransactionAwareDataSourceProxy}
+ * as an example of a wrapped {@link DataSource} for test cases.
+ */
+@Singleton
+@Requires(env = "test")
+class TransactionAwareDataSourceProxyResolver implements DataSourceResolver {
+
+    @Override
+    public DataSource resolve(DataSource dataSource) {
+        if (dataSource instanceof TransactionAwareDataSourceProxy transactionAwareDataSourceProxy) {
+            return transactionAwareDataSourceProxy.getTargetDataSource();
+        }
+
+        return dataSource;
+    }
+}

--- a/jdbc/src/main/java/io/micronaut/jdbc/CompositeDataSourceResolver.java
+++ b/jdbc/src/main/java/io/micronaut/jdbc/CompositeDataSourceResolver.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.jdbc;
+
+import io.micronaut.context.annotation.Primary;
+import jakarta.inject.Singleton;
+
+import javax.sql.DataSource;
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+/**
+ * A composite implementation combining all registered {@link DataSourceResolver} instances.
+ *
+ * @author Andreas Brenk
+ * @since 7.0.0
+ */
+@Singleton
+@Primary
+public class CompositeDataSourceResolver implements DataSourceResolver {
+
+    private final DataSourceResolver[] dataSourceResolvers;
+
+    /**
+     * Construct the CompositeDataSourceResolver from all data source resolvers.
+     *
+     * @param dataSourceResolvers The data source resolvers
+     */
+    public CompositeDataSourceResolver(DataSourceResolver[] dataSourceResolvers) {
+        this.dataSourceResolvers = dataSourceResolvers;
+    }
+
+    /**
+     * The underlying resolvers.
+     *
+     * @return The resolvers
+     */
+    public DataSourceResolver[] getDataSourceResolvers() {
+        return dataSourceResolvers;
+    }
+
+    /**
+     * Resolves the underlying target data source by iteratively unwrapping all proxying or instrumentation logic
+     * using the registered {@link DataSourceResolver} instances. Continues resolving until no further unwrapping is possible.
+     */
+    @Override
+    public DataSource resolve(DataSource dataSource) {
+        DataSource resolved = dataSource;
+
+        do {
+            dataSource = resolved;
+            for (DataSourceResolver resolver : dataSourceResolvers) {
+                resolved = resolver.resolve(dataSource);
+                if (resolved != dataSource) {
+                    break; // One layer was unwrapped, run the outer while loop from the start.
+                }
+            }
+        } while (resolved != dataSource); // If no resolver returned a different data source, we are done.
+
+        return resolved;
+    }
+
+    @Override
+    public String toString() {
+        return "CompositeDataSourceResolver(" + Arrays.stream(dataSourceResolvers).map(DataSourceResolver::toString).collect(Collectors.joining(",")) + ")";
+    }
+}

--- a/jdbc/src/test/groovy/io/micronaut/jdbc/CompositeDataSourceResolverSpec.groovy
+++ b/jdbc/src/test/groovy/io/micronaut/jdbc/CompositeDataSourceResolverSpec.groovy
@@ -1,0 +1,35 @@
+package io.micronaut.jdbc
+
+import io.micronaut.context.ApplicationContext
+import jakarta.inject.Singleton
+import spock.lang.Specification
+
+import javax.sql.DataSource
+
+class CompositeDataSourceResolverSpec extends Specification {
+
+    void "primary bean of type DataSourceResolver is CompositeDataSourceResolver"() {
+        given:
+        ApplicationContext context = ApplicationContext.run()
+
+        when:
+        def dataSourceResolver = context.getBean(DataSourceResolver)
+        // Would throw NonUniqueBeanException if not marked @Primary:
+        // Multiple possible bean candidates found: [CompositeDataSourceResolver, StubDataSourceResolver]
+
+        then:
+        dataSourceResolver instanceof CompositeDataSourceResolver
+
+        cleanup:
+        context.close()
+    }
+
+    @Singleton
+    static class StubDataSourceResolver implements DataSourceResolver {
+
+        @Override
+        DataSource resolve(DataSource dataSource) {
+            return dataSource
+        }
+    }
+}


### PR DESCRIPTION
Using instanceof does not work if the DataSource is wrapped by e.g. ContextualAwareDataSource or OpenTelemetryDataSource (or even multiple times).

I've added an implementation of `BeanCreatedListener<DataSource>` that just wraps the `DataSource` in a `TransactionAwareDataSourceProxy` as an example. And a new test class `ConnectionPoolManagerListenerSpec` that would fail if `instanceof` is used instead of `unwrap`.