### PR TITLE
feat: DataSourcePoolMetadata for Oracle UCP

### DIFF
--- a/jdbc-ucp/src/main/java/io/micronaut/configuration/jdbc/ucp/DatasourceFactory.java
+++ b/jdbc-ucp/src/main/java/io/micronaut/configuration/jdbc/ucp/DatasourceFactory.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.configuration.jdbc.ucp;
 
+import io.micronaut.configuration.jdbc.ucp.metadata.OracleUcpDataSourcePoolMetadata;
 import io.micronaut.context.ApplicationContext;
 import io.micronaut.context.annotation.Context;
 import io.micronaut.context.annotation.EachBean;
@@ -22,14 +23,17 @@ import io.micronaut.context.annotation.Factory;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.context.exceptions.NoSuchBeanException;
 import io.micronaut.jdbc.BaseDatasourceFactory;
+import io.micronaut.jdbc.DataSourceResolver;
 import io.micronaut.jdbc.JdbcDataSourceEnabled;
 import oracle.ucp.admin.UniversalConnectionPoolManager;
 import oracle.ucp.jdbc.PoolDataSource;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import jakarta.annotation.PreDestroy;
 
+import javax.sql.DataSource;
 import java.sql.SQLException;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -48,13 +52,16 @@ public class DatasourceFactory extends BaseDatasourceFactory implements AutoClos
 
     private final Map<String, PoolDataSource> dataSources = new LinkedHashMap<>(2);
     private UniversalConnectionPoolManager connectionPoolManager;
+    private final DataSourceResolver dataSourceResolver;
 
     /**
      * Default constructor.
      *
+     * @param dataSourceResolver The data source resolver
      * @param applicationContext The application context
      */
-    public DatasourceFactory(ApplicationContext applicationContext) {
+    public DatasourceFactory(@Nullable DataSourceResolver dataSourceResolver,
+                             ApplicationContext applicationContext) {
         super(applicationContext);
         this.configuration = applicationContext.getBean(UniversalConnectionPoolManagerConfiguration.class);
         try {
@@ -62,6 +69,7 @@ public class DatasourceFactory extends BaseDatasourceFactory implements AutoClos
         } catch (NoSuchBeanException e) {
             // no-op
         }
+        this.dataSourceResolver = dataSourceResolver == null ? DataSourceResolver.DEFAULT : dataSourceResolver;
     }
 
     /**
@@ -78,6 +86,23 @@ public class DatasourceFactory extends BaseDatasourceFactory implements AutoClos
         dataSources.put(datasourceConfiguration.getName(), ds);
 
         return ds;
+    }
+
+    /**
+     * Method to create a metadata object that allows pool value lookup for each datasource object.
+     *
+     * @param dataSource The actual datasource
+     * @return a {@link OracleUcpDataSourcePoolMetadata}
+     */
+    @EachBean(DataSource.class)
+    @Requires(beans = {DatasourceConfiguration.class})
+    public OracleUcpDataSourcePoolMetadata ucpDataSourcePoolMetadata(DataSource dataSource) {
+        OracleUcpDataSourcePoolMetadata ucpDataSourcePoolMetadata = null;
+
+        if (dataSourceResolver.resolve(dataSource) instanceof PoolDataSource resolved) {
+            ucpDataSourcePoolMetadata = new OracleUcpDataSourcePoolMetadata(resolved, connectionPoolManager);
+        }
+        return ucpDataSourcePoolMetadata;
     }
 
     @Override

--- a/jdbc-ucp/src/main/java/io/micronaut/configuration/jdbc/ucp/metadata/OracleUcpDataSourcePoolMetadata.java
+++ b/jdbc-ucp/src/main/java/io/micronaut/configuration/jdbc/ucp/metadata/OracleUcpDataSourcePoolMetadata.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.configuration.jdbc.ucp.metadata;
+
+import io.micronaut.jdbc.metadata.AbstractDataSourcePoolMetadata;
+import oracle.ucp.UniversalConnectionPool;
+import oracle.ucp.UniversalConnectionPoolException;
+import oracle.ucp.admin.UniversalConnectionPoolManager;
+import oracle.ucp.jdbc.PoolDataSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Optional;
+
+/**
+ * {@link io.micronaut.jdbc.metadata.DataSourcePoolMetadata} for an Oracle UCP {@link PoolDataSource}.
+ *
+ * @author Andreas Brenk
+ * @since 7.0.0
+ */
+public class OracleUcpDataSourcePoolMetadata
+    extends AbstractDataSourcePoolMetadata<PoolDataSource> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(OracleUcpDataSourcePoolMetadata.class);
+
+    private final UniversalConnectionPoolManager connectionPoolManager;
+
+    /**
+     * Oracle UCP typed {@link io.micronaut.jdbc.metadata.DataSourcePoolMetadata} object.
+     *
+     * @param dataSource The datasource
+     * @param connectionPoolManager The connection pool manager
+     */
+    public OracleUcpDataSourcePoolMetadata(PoolDataSource dataSource, UniversalConnectionPoolManager connectionPoolManager) {
+        super(dataSource);
+        this.connectionPoolManager = connectionPoolManager;
+    }
+
+    @Override
+    public Integer getIdle() {
+        return getConnectionPool()
+            .map(UniversalConnectionPool::getAvailableConnectionsCount)
+            .orElse(null);
+    }
+
+    @Override
+    public Integer getActive() {
+        return getConnectionPool()
+            .map(UniversalConnectionPool::getBorrowedConnectionsCount)
+            .orElse(null);
+    }
+
+    @Override
+    public Integer getMax() {
+        return getConnectionPool()
+            .map(UniversalConnectionPool::getMaxPoolSize)
+            .orElse(null);
+    }
+
+    @Override
+    public Integer getMin() {
+        return getConnectionPool()
+            .map(UniversalConnectionPool::getMinPoolSize)
+            .orElse(null);
+    }
+
+    @Override
+    public String getValidationQuery() {
+        return getDataSource().getSQLForValidateConnection();
+    }
+
+    @Override
+    public Boolean getDefaultAutoCommit() {
+        return getDataSource().isCommitOnConnectionReturn();
+    }
+
+    /**
+     * Get the {@link UniversalConnectionPool} from the {@link UniversalConnectionPoolManager}.
+     */
+    private Optional<UniversalConnectionPool> getConnectionPool() {
+        String poolName = getDataSource().getConnectionPoolName();
+
+        try {
+            return Optional.ofNullable(connectionPoolManager.getConnectionPool(poolName));
+        } catch (UniversalConnectionPoolException e) {
+            LOGGER.error("Could not get connection pool from connection pool manager", e);
+        }
+
+        return Optional.empty();
+    }
+
+}

--- a/jdbc-ucp/src/main/java/io/micronaut/configuration/jdbc/ucp/metadata/package-info.java
+++ b/jdbc-ucp/src/main/java/io/micronaut/configuration/jdbc/ucp/metadata/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Contains classes for reading JDBC metadata for Oracle UCP.
+ *
+ * @author Andreas Brenk
+ * @since 7.0.0
+ */
+package io.micronaut.configuration.jdbc.ucp.metadata;

--- a/jdbc-ucp/src/test/groovy/io/micronaut/configuration/jdbc/ucp/DatasourceConfigurationSpec.groovy
+++ b/jdbc-ucp/src/test/groovy/io/micronaut/configuration/jdbc/ucp/DatasourceConfigurationSpec.groovy
@@ -15,6 +15,7 @@
  */
 package io.micronaut.configuration.jdbc.ucp
 
+import io.micronaut.configuration.jdbc.ucp.metadata.OracleUcpDataSourcePoolMetadata
 import io.micronaut.context.ApplicationContext
 import io.micronaut.context.DefaultApplicationContext
 import io.micronaut.context.env.MapPropertySource
@@ -40,6 +41,7 @@ class DatasourceConfigurationSpec extends Specification {
         expect: "No beans are created"
         !applicationContext.containsBean(PoolDataSource)
         !applicationContext.containsBean(DatasourceConfiguration)
+        !applicationContext.containsBean(OracleUcpDataSourcePoolMetadata)
 
         cleanup:
         applicationContext.close()
@@ -65,6 +67,7 @@ class DatasourceConfigurationSpec extends Specification {
         expect:
         applicationContext.containsBean(PoolDataSource)
         applicationContext.containsBean(DatasourceConfiguration)
+        applicationContext.containsBean(OracleUcpDataSourcePoolMetadata)
 
         when:
         PoolDataSource dataSource = dataSourceResolver.resolve(applicationContext.getBean(DataSource))
@@ -94,6 +97,7 @@ class DatasourceConfigurationSpec extends Specification {
         expect:
         applicationContext.containsBean(PoolDataSource)
         applicationContext.containsBean(DatasourceConfiguration)
+        applicationContext.containsBean(OracleUcpDataSourcePoolMetadata)
 
         when:
         PoolDataSource dataSource = dataSourceResolver.resolve(applicationContext.getBean(DataSource))
@@ -179,6 +183,11 @@ class DatasourceConfigurationSpec extends Specification {
         when:
         applicationContext.getBean(DataSource, Qualifiers.byName('default'))
 
+        then:
+        thrown(NoSuchBeanException)
+
+        when:
+        applicationContext.getBean(OracleUcpDataSourcePoolMetadata, Qualifiers.byName('default'))
         then:
         thrown(NoSuchBeanException)
 
@@ -361,6 +370,47 @@ class DatasourceConfigurationSpec extends Specification {
         dataSource.getInactiveConnectionTimeout() == 10
         dataSource.getConnectionWaitDuration() == Duration.ofSeconds(10)
         dataSource.getLoginTimeout() == 20
+
+        cleanup:
+        applicationContext.close()
+    }
+
+    void "test multiple datasources metadata props"() {
+        given:
+        String context = UUID.randomUUID().toString()
+        ApplicationContext applicationContext = new DefaultApplicationContext(context)
+        applicationContext.environment.addPropertySource(MapPropertySource.of(
+                context,
+                [
+                        'datasources.default.initialPoolSize'          : 5,
+                        'datasources.default.minPoolSize'              : 5,
+                        'datasources.default.maxPoolSize'              : 20,
+
+                        'datasources.person.initialPoolSize'           : 1,
+                        'datasources.person.minPoolSize'               : 1,
+                        'datasources.person.maxPoolSize'               : 10,
+                ]
+        ))
+        applicationContext.start()
+
+        def metadataDefault = applicationContext.getBean(OracleUcpDataSourcePoolMetadata, Qualifiers.byName("default"))
+        def metadataPerson = applicationContext.getBean(OracleUcpDataSourcePoolMetadata, Qualifiers.byName("person"))
+
+        expect:
+        verifyAll {
+            applicationContext.getBeansOfType(DataSource).size() == 2
+            applicationContext.getBeansOfType(DatasourceConfiguration).size() == 2
+
+            metadataDefault.max == 20
+            metadataDefault.min == 5
+            metadataDefault.active == 0
+            metadataDefault.idle >= 0
+
+            metadataPerson.max == 10
+            metadataPerson.min == 1
+            metadataPerson.active == 0
+            metadataPerson.idle >= 0
+        }
 
         cleanup:
         applicationContext.close()

--- a/jdbc-ucp/src/test/groovy/io/micronaut/configuration/jdbc/ucp/metadata/AbstractDataSourcePoolMetadataSpec.groovy
+++ b/jdbc-ucp/src/test/groovy/io/micronaut/configuration/jdbc/ucp/metadata/AbstractDataSourcePoolMetadataSpec.groovy
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.configuration.jdbc.ucp.metadata
+
+import spock.lang.Shared
+import spock.lang.Specification
+
+class AbstractDataSourcePoolMetadataSpec extends Specification {
+
+    @Shared
+    def metricNames = [
+            'jdbc.connections.usage',
+            'jdbc.connections.active',
+            'jdbc.connections.max',
+            'jdbc.connections.min'
+    ]
+
+}

--- a/jdbc-ucp/src/test/groovy/io/micronaut/configuration/jdbc/ucp/metadata/OracleUcpDataSourcePoolMetadataDisabledSpec.groovy
+++ b/jdbc-ucp/src/test/groovy/io/micronaut/configuration/jdbc/ucp/metadata/OracleUcpDataSourcePoolMetadataDisabledSpec.groovy
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.configuration.jdbc.ucp.metadata
+
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.env.MapPropertySource
+import io.micronaut.http.HttpStatus
+import io.micronaut.http.client.HttpClient
+import io.micronaut.http.client.exceptions.HttpClientResponseException
+import io.micronaut.runtime.server.EmbeddedServer
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+import spock.lang.Unroll
+
+import static io.micronaut.configuration.metrics.micrometer.MeterRegistryFactory.MICRONAUT_METRICS_BINDERS
+import static io.micronaut.configuration.metrics.micrometer.MeterRegistryFactory.MICRONAUT_METRICS_ENABLED
+
+class OracleUcpDataSourcePoolMetadataDisabledSpec extends AbstractDataSourcePoolMetadataSpec {
+
+    @Shared
+    @AutoCleanup
+    ApplicationContext context = ApplicationContext.run(MapPropertySource.of(
+            this.class.getSimpleName(),
+            ['datasources.default'                        : [:],
+             'datasources.foo'                            : [:],
+             'endpoints.metrics.sensitive'                : false,
+             (MICRONAUT_METRICS_ENABLED)                  : true,
+             (MICRONAUT_METRICS_BINDERS + ".jdbc.enabled"): false]
+    ), this.class.getSimpleName())
+
+    @Shared
+    @AutoCleanup
+    EmbeddedServer embeddedServer = context.getBean(EmbeddedServer).start()
+
+    @Shared
+    @AutoCleanup
+    HttpClient httpClient = context.createBean(HttpClient, embeddedServer.getURL())
+
+    @Unroll
+    def "check metrics endpoint for datasource metrics not found for #metric"() {
+        when:
+        def response = httpClient.toBlocking().exchange("/metrics", Map)
+        Map result = response.body()
+
+        then:
+        response.code() == HttpStatus.OK.code
+        !result.names.contains(metric)
+
+        where:
+        metric << metricNames
+    }
+
+    @Unroll
+    def "check metrics endpoint for datasource metrics #metric not found"() {
+        when:
+        httpClient.toBlocking().exchange("/metrics/$metric", Map)
+
+        then:
+        thrown(HttpClientResponseException)
+
+        where:
+        metric << metricNames
+    }
+
+}

--- a/jdbc-ucp/src/test/groovy/io/micronaut/configuration/jdbc/ucp/metadata/OracleUcpDataSourcePoolMetadataSpec.groovy
+++ b/jdbc-ucp/src/test/groovy/io/micronaut/configuration/jdbc/ucp/metadata/OracleUcpDataSourcePoolMetadataSpec.groovy
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.configuration.jdbc.ucp.metadata
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.env.MapPropertySource
+import io.micronaut.http.HttpStatus
+import io.micronaut.http.client.HttpClient
+import io.micronaut.runtime.server.EmbeddedServer
+import oracle.ucp.UniversalConnectionPool
+import oracle.ucp.admin.UniversalConnectionPoolManager
+import oracle.ucp.jdbc.PoolDataSource
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+
+import static io.micronaut.configuration.metrics.micrometer.MeterRegistryFactory.MICRONAUT_METRICS_BINDERS
+import static io.micronaut.configuration.metrics.micrometer.MeterRegistryFactory.MICRONAUT_METRICS_ENABLED
+
+class OracleUcpDataSourcePoolMetadataSpec extends AbstractDataSourcePoolMetadataSpec {
+
+    @Shared
+    @AutoCleanup
+    ApplicationContext context = ApplicationContext.run(MapPropertySource.of(
+            this.class.getSimpleName(),
+            ['datasources.default'                        : [:],
+             'datasources.foo'                            : [:],
+             'endpoints.metrics.sensitive'                : false,
+             (MICRONAUT_METRICS_ENABLED)                  : true,
+             (MICRONAUT_METRICS_BINDERS + ".jdbc.enabled"): true]
+    ), this.class.getSimpleName())
+
+    @Shared
+    @AutoCleanup
+    EmbeddedServer embeddedServer = context.getBean(EmbeddedServer).start()
+
+    @Shared
+    @AutoCleanup
+    HttpClient httpClient = context.createBean(HttpClient, embeddedServer.getURL())
+
+    def "test wire class manually"() {
+        given:
+        UniversalConnectionPoolManager poolManager = Mock(UniversalConnectionPoolManager)
+        UniversalConnectionPool pool = Mock(UniversalConnectionPool)
+        PoolDataSource dataSource = Mock(PoolDataSource)
+
+        when:
+        def metadata = new OracleUcpDataSourcePoolMetadata(dataSource, poolManager)
+        metadata.getActive() // pool access happens lazily
+
+        then:
+        1 * dataSource.getConnectionPoolName() >> "JDBC_UCP"
+        1 * poolManager.getConnectionPool("JDBC_UCP") >> pool
+        metadata
+        metadata.getActive() == null
+        metadata.getDefaultAutoCommit() == false
+        metadata.getIdle() == null
+        metadata.getMax() == null
+        metadata.getMin() == null
+    }
+
+    def "check metrics endpoint for datasource metrics for #metric"() {
+        when:
+        def response = httpClient.toBlocking().exchange("/metrics", Map)
+        Map result = response.body()
+
+        then:
+        response.code() == HttpStatus.OK.code
+        result.names.contains(metric)
+
+        where:
+        metric << metricNames
+
+    }
+
+    def "check metrics endpoint for datasource metrics #metric"() {
+        when:
+        def response = httpClient.toBlocking().exchange("/metrics/$metric", Map)
+        Map result = (Map) response.body()
+
+        then:
+        response.code() == HttpStatus.OK.code
+        result.name == metric
+
+        when:
+        def tags = result.availableTags.findAll {
+            it.tag == 'name'
+        }
+
+        then:
+        tags
+
+        and:
+        tags.each { Map tag ->
+            assert tag.values.contains('default')
+            assert tag.values.contains('foo')
+        }
+
+        where:
+        metric << metricNames
+    }
+
+}


### PR DESCRIPTION
This enable the same Micrometer metrics as for the Tomcat and DBCP connection pools:
```
# HELP jdbc_connections_active  
# TYPE jdbc_connections_active gauge
jdbc_connections_active{name="default"} 0.0
# HELP jdbc_connections_max  
# TYPE jdbc_connections_max gauge
jdbc_connections_max{name="default"} 10.0
# HELP jdbc_connections_min  
# TYPE jdbc_connections_min gauge
jdbc_connections_min{name="default"} 1.0
# HELP jdbc_connections_usage  
# TYPE jdbc_connections_usage gauge
jdbc_connections_usage{name="default"} 0.0
```

After the merge the Micronaut Micrometer documentation on DataSource Metrics should be extended:
https://micronaut-projects.github.io/micronaut-micrometer/5.13.2/guide/#_datasource_metrics