### PR TITLE
fix(jdbi): publish jdbi bom to consumers

### DIFF
--- a/jdbi/build.gradle
+++ b/jdbi/build.gradle
@@ -18,6 +18,7 @@ dependencies {
     api projects.micronautJdbc
     api(mn.micronaut.aop)
     api(mn.micronaut.inject)
+    api(platform(libs.boms.jdbi3))
     api(libs.jdbi3.core) {
         exclude group:'com.github.ben-manes.caffeine', module:'caffeine'
     }

--- a/jdbi/build.gradle
+++ b/jdbi/build.gradle
@@ -18,7 +18,7 @@ dependencies {
     api projects.micronautJdbc
     api(mn.micronaut.aop)
     api(mn.micronaut.inject)
-    implementation(platform(libs.boms.jdbi3))
+    api(platform(libs.boms.jdbi3))
     api(libs.jdbi3.core) {
         exclude group:'com.github.ben-manes.caffeine', module:'caffeine'
     }

--- a/jdbi/build.gradle
+++ b/jdbi/build.gradle
@@ -18,7 +18,7 @@ dependencies {
     api projects.micronautJdbc
     api(mn.micronaut.aop)
     api(mn.micronaut.inject)
-    api(platform(libs.boms.jdbi3))
+    implementation(platform(libs.boms.jdbi3))
     api(libs.jdbi3.core) {
         exclude group:'com.github.ben-manes.caffeine', module:'caffeine'
     }

--- a/src/main/docs/guide/jdbi.adoc
+++ b/src/main/docs/guide/jdbi.adoc
@@ -4,6 +4,42 @@ To configure the Jdbi library you should first add the `jdbi` module to your cla
 
 dependency:micronaut-jdbi[groupId="io.micronaut.sql"]
 
+If you need additional Jdbi modules such as `jdbi3-sqlobject`, Gradle consumers can declare them without an explicit version because `micronaut-jdbi` publishes the Jdbi BOM through Gradle module metadata:
+
+[source,groovy]
+----
+implementation("io.micronaut.sql:micronaut-jdbi")
+implementation("org.jdbi:jdbi3-sqlobject")
+----
+
+For Maven, import `micronaut-sql-bom` in `dependencyManagement` before declaring extra Jdbi modules, because Maven does not consume transitive BOM imports from regular dependencies:
+
+[source,xml]
+----
+<dependencyManagement>
+  <dependencies>
+    <dependency>
+      <groupId>io.micronaut.sql</groupId>
+      <artifactId>micronaut-sql-bom</artifactId>
+      <version>${micronaut.sql.version}</version>
+      <type>pom</type>
+      <scope>import</scope>
+    </dependency>
+  </dependencies>
+</dependencyManagement>
+
+<dependencies>
+  <dependency>
+    <groupId>io.micronaut.sql</groupId>
+    <artifactId>micronaut-jdbi</artifactId>
+  </dependency>
+  <dependency>
+    <groupId>org.jdbi</groupId>
+    <artifactId>jdbi3-sqlobject</artifactId>
+  </dependency>
+</dependencies>
+----
+
 You should then <<jdbc, configure one or many DataSources>>.
 For each registered `DataSource`, Micronaut will configure the following Jdbi beans using api:configuration.jdbi.JdbiFactory[]:
 


### PR DESCRIPTION
## Summary
- restore the Jdbi BOM export from `micronaut-jdbi` for Gradle consumers by publishing it as an `api(platform(...))` dependency
- document the Maven-compatible path by importing `micronaut-sql-bom` before adding extra Jdbi modules such as `jdbi3-sqlobject`
- keep `jdbi3-core` on the managed version while clarifying the Gradle vs Maven behavior in the guide

## Verification
- `./gradlew :micronaut-jdbi:test :micronaut-jdbc:publishMavenPublicationToBuildRepository :micronaut-jdbc-hikari:publishMavenPublicationToBuildRepository :micronaut-jdbi:publishMavenPublicationToBuildRepository :micronaut-sql-bom:publishMavenPublicationToBuildRepository`
- `./gradlew -p /Users/graemerocher/dev/multicode-workspaces/sql/work/micronaut-sql-839/.tmp-verify/gradle-app --refresh-dependencies compileJava dependencyInsight --configuration runtimeClasspath --dependency org.jdbi:jdbi3-sqlobject`
- `./mvnw -U -DskipTests compile dependency:tree -Dincludes=io.micronaut.sql:micronaut-jdbi,org.jdbi:jdbi3-sqlobject,org.jdbi:jdbi3-core` from a scratch Maven app importing `io.micronaut.sql:micronaut-sql-bom`
- `./gradlew docs`

Resolves #839
