### PR TITLE
fix(jooq): resolve DSLContext injection ambiguity

### DIFF
--- a/jooq/src/main/java/io/micronaut/configuration/jooq/AbstractJooqConfigurationFactory.java
+++ b/jooq/src/main/java/io/micronaut/configuration/jooq/AbstractJooqConfigurationFactory.java
@@ -60,7 +60,8 @@ abstract class AbstractJooqConfigurationFactory {
      * @return A {@link org.jooq.Configuration}
      */
     @SuppressWarnings("checkstyle:ParameterNumber")
-    protected DefaultConfiguration jooqConfiguration(
+    protected <T extends DefaultConfiguration> T configureConfiguration(
+        T configuration,
         @Parameter String name,
         @Parameter @Nullable TransactionProvider transactionProvider,
         @Parameter @Nullable Settings settings,
@@ -72,8 +73,6 @@ abstract class AbstractJooqConfigurationFactory {
         AbstractJooqConfigurationProperties properties,
         ApplicationContext ctx
     ) {
-        DefaultConfiguration configuration = new DefaultConfiguration();
-
         if (transactionProvider != null) {
             configuration.setTransactionProvider(transactionProvider);
         }

--- a/jooq/src/main/java/io/micronaut/configuration/jooq/DSLContextFactory.java
+++ b/jooq/src/main/java/io/micronaut/configuration/jooq/DSLContextFactory.java
@@ -67,20 +67,26 @@ final class DSLContextFactory {
     @Singleton
     @Requires(beans = R2dbcConfiguration.class)
     DSLContext primaryR2dbcDslContext(@Any BeanProvider<R2dbcConfiguration> configurations) {
-        R2dbcConfiguration configuration = configurations.find(Qualifiers.byStereotype(Primary.class))
-            .or(() -> configurations.find(Qualifiers.byName("default")))
-            .orElseGet(() -> singleConfiguration(configurations));
+        R2dbcConfiguration configuration = selectR2dbcConfiguration(configurations);
         return createDslContext(configuration);
     }
 
-    private R2dbcConfiguration singleConfiguration(BeanProvider<R2dbcConfiguration> configurations) {
+    private R2dbcConfiguration selectR2dbcConfiguration(BeanProvider<R2dbcConfiguration> configurations) {
+        return configurations.find(Qualifiers.byStereotype(Primary.class))
+            .or(() -> configurations.find(Qualifiers.byName("default")))
+            .orElseGet(() -> requireSingleConfiguration(configurations));
+    }
+
+    private R2dbcConfiguration requireSingleConfiguration(BeanProvider<R2dbcConfiguration> configurations) {
         var iterator = configurations.iterator();
-        if (!iterator.hasNext()) {
-            throw new IllegalStateException("No R2DBC configuration found");
-        }
         var configuration = iterator.next();
         if (iterator.hasNext()) {
-            throw new IllegalStateException("Multiple R2DBC configurations found. Mark one @Primary or name one 'default'");
+            int candidateCount = 2;
+            while (iterator.hasNext()) {
+                iterator.next();
+                candidateCount++;
+            }
+            throw new IllegalStateException("Multiple R2DBC configurations found (" + candidateCount + "). Mark one @Primary or name one 'default'");
         }
         return configuration;
     }

--- a/jooq/src/main/java/io/micronaut/configuration/jooq/DSLContextFactory.java
+++ b/jooq/src/main/java/io/micronaut/configuration/jooq/DSLContextFactory.java
@@ -22,6 +22,7 @@ import io.micronaut.context.annotation.Factory;
 import io.micronaut.context.annotation.Parameter;
 import io.micronaut.context.annotation.Primary;
 import io.micronaut.context.annotation.Requires;
+import io.micronaut.context.annotation.Secondary;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.inject.qualifiers.Qualifiers;
 import io.micronaut.transaction.TransactionStatus;
@@ -51,11 +52,13 @@ final class DSLContextFactory {
      * @return A {@link DSLContext}
      */
     @EachBean(JdbcConfiguration.class)
+    @Secondary
     DSLContext dslContext(@Parameter JdbcConfiguration configuration) {
         return createDslContext(configuration);
     }
 
     @EachBean(R2dbcConfiguration.class)
+    @Secondary
     DSLContext r2dbcDslContext(@Parameter R2dbcConfiguration configuration) {
         return createDslContext(configuration);
     }
@@ -66,8 +69,20 @@ final class DSLContextFactory {
     DSLContext primaryR2dbcDslContext(@Any BeanProvider<R2dbcConfiguration> configurations) {
         R2dbcConfiguration configuration = configurations.find(Qualifiers.byStereotype(Primary.class))
             .or(() -> configurations.find(Qualifiers.byName("default")))
-            .orElseGet(() -> configurations.iterator().next());
+            .orElseGet(() -> singleConfiguration(configurations));
         return createDslContext(configuration);
+    }
+
+    private R2dbcConfiguration singleConfiguration(BeanProvider<R2dbcConfiguration> configurations) {
+        var iterator = configurations.iterator();
+        if (!iterator.hasNext()) {
+            throw new IllegalStateException("No R2DBC configuration found");
+        }
+        var configuration = iterator.next();
+        if (iterator.hasNext()) {
+            throw new IllegalStateException("Multiple R2DBC configurations found. Mark one @Primary or name one 'default'");
+        }
+        return configuration;
     }
 
     private DSLContext createDslContext(Configuration configuration) {

--- a/jooq/src/main/java/io/micronaut/configuration/jooq/DSLContextFactory.java
+++ b/jooq/src/main/java/io/micronaut/configuration/jooq/DSLContextFactory.java
@@ -17,6 +17,8 @@ package io.micronaut.configuration.jooq;
 
 import io.micronaut.context.annotation.EachBean;
 import io.micronaut.context.annotation.Factory;
+import io.micronaut.context.annotation.Parameter;
+import io.micronaut.context.annotation.Primary;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.transaction.TransactionStatus;
 import io.micronaut.transaction.support.ExceptionUtil;
@@ -43,8 +45,18 @@ final class DSLContextFactory {
      * @param configuration The {@link Configuration}
      * @return A {@link DSLContext}
      */
-    @EachBean(Configuration.class)
-    DSLContext dslContext(Configuration configuration) {
+    @EachBean(JdbcConfiguration.class)
+    DSLContext dslContext(@Parameter JdbcConfiguration configuration) {
+        return createDslContext(configuration);
+    }
+
+    @Primary
+    @EachBean(R2dbcConfiguration.class)
+    DSLContext r2dbcDslContext(@Parameter R2dbcConfiguration configuration) {
+        return createDslContext(configuration);
+    }
+
+    private DSLContext createDslContext(Configuration configuration) {
         return new DefaultDSLContext(configuration) {
 
             @Override

--- a/jooq/src/main/java/io/micronaut/configuration/jooq/DSLContextFactory.java
+++ b/jooq/src/main/java/io/micronaut/configuration/jooq/DSLContextFactory.java
@@ -15,13 +15,18 @@
  */
 package io.micronaut.configuration.jooq;
 
+import io.micronaut.context.BeanProvider;
+import io.micronaut.context.annotation.Any;
 import io.micronaut.context.annotation.EachBean;
 import io.micronaut.context.annotation.Factory;
 import io.micronaut.context.annotation.Parameter;
 import io.micronaut.context.annotation.Primary;
+import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.annotation.Internal;
+import io.micronaut.inject.qualifiers.Qualifiers;
 import io.micronaut.transaction.TransactionStatus;
 import io.micronaut.transaction.support.ExceptionUtil;
+import jakarta.inject.Singleton;
 import org.jooq.Configuration;
 import org.jooq.DSLContext;
 import org.jooq.TransactionProperty;
@@ -50,9 +55,18 @@ final class DSLContextFactory {
         return createDslContext(configuration);
     }
 
-    @Primary
     @EachBean(R2dbcConfiguration.class)
     DSLContext r2dbcDslContext(@Parameter R2dbcConfiguration configuration) {
+        return createDslContext(configuration);
+    }
+
+    @Primary
+    @Singleton
+    @Requires(beans = R2dbcConfiguration.class)
+    DSLContext primaryR2dbcDslContext(@Any BeanProvider<R2dbcConfiguration> configurations) {
+        R2dbcConfiguration configuration = configurations.find(Qualifiers.byStereotype(Primary.class))
+            .or(() -> configurations.find(Qualifiers.byName("default")))
+            .orElseGet(() -> configurations.iterator().next());
         return createDslContext(configuration);
     }
 

--- a/jooq/src/main/java/io/micronaut/configuration/jooq/JdbcConfiguration.java
+++ b/jooq/src/main/java/io/micronaut/configuration/jooq/JdbcConfiguration.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.configuration.jooq;
+
+import io.micronaut.core.annotation.Internal;
+import org.jooq.impl.DefaultConfiguration;
+
+/**
+ * Internal JDBC-backed jOOQ configuration bean type.
+ *
+ * @since 7.0.0
+ */
+@Internal
+final class JdbcConfiguration extends DefaultConfiguration {
+}

--- a/jooq/src/main/java/io/micronaut/configuration/jooq/JooqConfigurationFactory.java
+++ b/jooq/src/main/java/io/micronaut/configuration/jooq/JooqConfigurationFactory.java
@@ -20,7 +20,6 @@ import io.micronaut.context.annotation.EachBean;
 import io.micronaut.context.annotation.Factory;
 import io.micronaut.context.annotation.Parameter;
 import io.micronaut.core.annotation.Internal;
-import org.jspecify.annotations.Nullable;
 import io.micronaut.jdbc.DataSourceResolver;
 import org.jooq.Configuration;
 import org.jooq.ConnectionProvider;
@@ -31,7 +30,7 @@ import org.jooq.RecordMapperProvider;
 import org.jooq.RecordUnmapperProvider;
 import org.jooq.TransactionProvider;
 import org.jooq.conf.Settings;
-import org.jooq.impl.DefaultConfiguration;
+import org.jspecify.annotations.Nullable;
 
 import javax.sql.DataSource;
 
@@ -66,7 +65,7 @@ final class JooqConfigurationFactory extends AbstractJooqConfigurationFactory {
      */
     @SuppressWarnings("checkstyle:ParameterNumber")
     @EachBean(DataSource.class)
-    Configuration jooqConfiguration(
+    JdbcConfiguration jooqConfiguration(
         @Parameter String name,
         DataSource dataSource,
         @Parameter @Nullable TransactionProvider transactionProvider,
@@ -89,7 +88,7 @@ final class JooqConfigurationFactory extends AbstractJooqConfigurationFactory {
             dataSourceResolver = DataSourceResolver.DEFAULT;
         }
 
-        DefaultConfiguration configuration = super.jooqConfiguration(name, transactionProvider, settings, executorProvider,
+        JdbcConfiguration configuration = super.configureConfiguration(new JdbcConfiguration(), name, transactionProvider, settings, executorProvider,
             recordMapperProvider, recordUnmapperProvider, metaProvider, converterProvider, properties, ctx);
 
         if (connectionProvider != null) {

--- a/jooq/src/main/java/io/micronaut/configuration/jooq/R2dbcConfiguration.java
+++ b/jooq/src/main/java/io/micronaut/configuration/jooq/R2dbcConfiguration.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.configuration.jooq;
+
+import io.micronaut.core.annotation.Internal;
+import org.jooq.impl.DefaultConfiguration;
+
+/**
+ * Internal R2DBC-backed jOOQ configuration bean type.
+ *
+ * @since 7.0.0
+ */
+@Internal
+final class R2dbcConfiguration extends DefaultConfiguration {
+}

--- a/jooq/src/main/java/io/micronaut/configuration/jooq/R2dbcJooqConfigurationFactory.java
+++ b/jooq/src/main/java/io/micronaut/configuration/jooq/R2dbcJooqConfigurationFactory.java
@@ -21,7 +21,6 @@ import io.micronaut.context.annotation.Factory;
 import io.micronaut.context.annotation.Parameter;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.annotation.Internal;
-import org.jspecify.annotations.Nullable;
 import io.r2dbc.spi.ConnectionFactory;
 import org.jooq.Configuration;
 import org.jooq.ConverterProvider;
@@ -32,7 +31,7 @@ import org.jooq.RecordUnmapperProvider;
 import org.jooq.SQLDialect;
 import org.jooq.TransactionProvider;
 import org.jooq.conf.Settings;
-import org.jooq.impl.DefaultConfiguration;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Sets up R2DBC jOOQ library integration.
@@ -64,7 +63,7 @@ final class R2dbcJooqConfigurationFactory extends AbstractJooqConfigurationFacto
      */
     @SuppressWarnings("checkstyle:MethodLength")
     @EachBean(ConnectionFactory.class)
-    Configuration jooqConfiguration(
+    R2dbcConfiguration jooqConfiguration(
         @Parameter String name,
         ConnectionFactory connectionFactory,
         @Parameter @Nullable TransactionProvider transactionProvider,
@@ -81,7 +80,7 @@ final class R2dbcJooqConfigurationFactory extends AbstractJooqConfigurationFacto
             properties = new R2dbcJooqConfigurationProperties();
         }
 
-        DefaultConfiguration configuration = super.jooqConfiguration(name, transactionProvider, settings, executorProvider,
+        R2dbcConfiguration configuration = super.configureConfiguration(new R2dbcConfiguration(), name, transactionProvider, settings, executorProvider,
             recordMapperProvider, recordUnmapperProvider, metaProvider, converterProvider, properties, ctx);
 
         configuration.setSQLDialect(getSqlDialect(properties));

--- a/jooq/src/test/groovy/io/micronaut/configuration/jooq/DslContextFactorySpec.groovy
+++ b/jooq/src/test/groovy/io/micronaut/configuration/jooq/DslContextFactorySpec.groovy
@@ -72,6 +72,12 @@ class DslContextFactorySpec extends Specification {
         }
 
         @Singleton
+        @Named("analytics")
+        ConnectionFactory analyticsConnectionFactory() {
+            return proxy(ConnectionFactory)
+        }
+
+        @Singleton
         @Named("default")
         JooqConfigurationProperties jdbcJooqProperties() {
             JooqConfigurationProperties configurationProperties = new JooqConfigurationProperties()
@@ -84,6 +90,14 @@ class DslContextFactorySpec extends Specification {
         R2dbcJooqConfigurationProperties r2dbcJooqProperties() {
             R2dbcJooqConfigurationProperties configurationProperties = new R2dbcJooqConfigurationProperties()
             configurationProperties.sqlDialect = SQLDialect.POSTGRES
+            return configurationProperties
+        }
+
+        @Singleton
+        @Named("analytics")
+        R2dbcJooqConfigurationProperties analyticsR2dbcJooqProperties() {
+            R2dbcJooqConfigurationProperties configurationProperties = new R2dbcJooqConfigurationProperties()
+            configurationProperties.sqlDialect = SQLDialect.MYSQL
             return configurationProperties
         }
 

--- a/jooq/src/test/groovy/io/micronaut/configuration/jooq/DslContextFactorySpec.groovy
+++ b/jooq/src/test/groovy/io/micronaut/configuration/jooq/DslContextFactorySpec.groovy
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.configuration.jooq
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Factory
+import io.micronaut.context.annotation.Requires
+import io.r2dbc.spi.ConnectionFactory
+import jakarta.inject.Named
+import jakarta.inject.Singleton
+import org.jooq.DSLContext
+import org.jooq.SQLDialect
+import spock.lang.Specification
+
+import javax.sql.DataSource
+import java.lang.reflect.Proxy
+
+class DslContextFactorySpec extends Specification {
+
+    void "test default dsl context can be injected with jdbc and r2dbc configurations"() {
+        given:
+        ApplicationContext applicationContext = ApplicationContext.run("multiple-config")
+
+        when:
+        TestService testService = applicationContext.getBean(TestService)
+
+        then:
+        testService.dslContext != null
+        testService.dslContext.configuration() instanceof R2dbcConfiguration
+
+        cleanup:
+        applicationContext.close()
+    }
+
+    @Singleton
+    @Requires(env = "multiple-config")
+    static class TestService {
+        final DSLContext dslContext
+
+        TestService(DSLContext dslContext) {
+            this.dslContext = dslContext
+        }
+    }
+
+    @Factory
+    @Requires(env = "multiple-config")
+    static class TestConnectionFactory {
+
+        @Singleton
+        @Named("default")
+        DataSource dataSource() {
+            return proxy(DataSource)
+        }
+
+        @Singleton
+        @Named("default")
+        ConnectionFactory connectionFactory() {
+            return proxy(ConnectionFactory)
+        }
+
+        @Singleton
+        @Named("default")
+        JooqConfigurationProperties jdbcJooqProperties() {
+            JooqConfigurationProperties configurationProperties = new JooqConfigurationProperties()
+            configurationProperties.sqlDialect = SQLDialect.H2
+            return configurationProperties
+        }
+
+        @Singleton
+        @Named("default")
+        R2dbcJooqConfigurationProperties r2dbcJooqProperties() {
+            R2dbcJooqConfigurationProperties configurationProperties = new R2dbcJooqConfigurationProperties()
+            configurationProperties.sqlDialect = SQLDialect.POSTGRES
+            return configurationProperties
+        }
+
+        private static <T> T proxy(Class<T> type) {
+            return (T) Proxy.newProxyInstance(type.classLoader, [type] as Class<?>[]) { _, method, _ ->
+                if (method.name == "toString") {
+                    return type.simpleName
+                }
+                if (method.returnType == Boolean.TYPE) {
+                    return false
+                }
+                if (method.returnType == Integer.TYPE) {
+                    return 0
+                }
+                return null
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- split the internal jOOQ JDBC and R2DBC configuration beans into distinct types
- create separate DSLContext beans and make the R2DBC-backed DSLContext primary when both are present
- add a focused regression spec covering default DSLContext injection with JDBC and R2DBC together

## Verification
- ./gradlew :micronaut-jooq:test --tests 'io.micronaut.configuration.jooq.DslContextFactorySpec'\n- ./gradlew :micronaut-jooq:test\n- ./gradlew :micronaut-jooq:txTest\n- ./gradlew :micronaut-jooq:spotlessCheck
 
Resolves #1292