### PR TITLE
test(vertx-pg-client): add native pg codec regression coverage

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -65,6 +65,7 @@ include 'tests:hibernate:hibernate-reactive-postgres'
 
 include 'tests:jooq-tests:jooq-jdbc-postgres'
 include 'tests:jooq-tests:jooq-r2dbc-postgres'
+include 'tests:vertx-pg-client-native'
 
 include 'tests:jdbc-ucp-tests:jdbc-ucp-oracle'
 include 'tests:jdbc-dbcp-tests:jdbc-dbcp-postgres'

--- a/tests/vertx-pg-client-native/build.gradle
+++ b/tests/vertx-pg-client-native/build.gradle
@@ -1,0 +1,42 @@
+plugins {
+    id 'io.micronaut.build.internal.testing-base'
+    id 'io.micronaut.application'
+}
+
+micronaut {
+    importMicronautPlatform = false
+    runtime "netty"
+    testRuntime "junit"
+}
+
+dependencies {
+    runtimeOnly mnLogging.logback.classic
+    implementation mn.micronaut.http.client
+    implementation projects.micronautVertxPgClient
+
+    testImplementation mnTest.micronaut.test.core
+    testImplementation mnTest.micronaut.test.junit5
+
+    micronautBoms(platform(mn.micronaut.core.bom))
+    micronautBoms(platform(mnData.micronaut.data.bom))
+}
+
+application {
+    mainClass = "example.Application"
+}
+
+configurations.all {
+    resolutionStrategy.preferProjectModules()
+}
+
+graalvmNative {
+    toolchainDetection = false
+    binaries {
+        all {
+            buildArgs.add("--report-unsupported-elements-at-runtime")
+        }
+    }
+    metadataRepository {
+        enabled = true
+    }
+}

--- a/tests/vertx-pg-client-native/src/main/java/example/Application.java
+++ b/tests/vertx-pg-client-native/src/main/java/example/Application.java
@@ -1,0 +1,10 @@
+package example;
+
+import io.micronaut.runtime.Micronaut;
+
+public class Application {
+
+    public static void main(String[] args) {
+        Micronaut.run(Application.class);
+    }
+}

--- a/tests/vertx-pg-client-native/src/main/java/example/PgCodecController.java
+++ b/tests/vertx-pg-client-native/src/main/java/example/PgCodecController.java
@@ -1,0 +1,15 @@
+package example;
+
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Get;
+import io.vertx.pgclient.impl.codec.DataTypeCodec;
+
+@Controller("/postgres")
+final class PgCodecController {
+
+    @Get("/codec")
+    String codec() {
+        return DataTypeCodec.LDT_PLUS_INFINITY.getYear() > 0
+            && DataTypeCodec.LDT_MINUS_INFINITY.getYear() < 0 ? "ok" : "invalid";
+    }
+}

--- a/tests/vertx-pg-client-native/src/test/java/example/PgCodecNativeTest.java
+++ b/tests/vertx-pg-client-native/src/test/java/example/PgCodecNativeTest.java
@@ -1,0 +1,22 @@
+package example;
+
+import io.micronaut.http.client.HttpClient;
+import io.micronaut.http.client.annotation.Client;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@MicronautTest
+class PgCodecNativeTest {
+
+    @Inject
+    @Client("/")
+    HttpClient client;
+
+    @Test
+    void canInitializeVertxPgCodec() {
+        assertEquals("ok", client.toBlocking().retrieve("/postgres/codec"));
+    }
+}

--- a/tests/vertx-pg-client-native/src/test/resources/logback.xml
+++ b/tests/vertx-pg-client-native/src/test/resources/logback.xml
@@ -1,0 +1,10 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+    <root level="info">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>


### PR DESCRIPTION
## Summary
- add a minimal native Micronaut test application for `micronaut-vertx-pg-client`
- exercise Vert.x `DataTypeCodec` through an HTTP endpoint under `nativeTest`
- capture the historical GraalVM issue with a focused regression on the current 7.0.x line

## Verification
- `./gradlew -q :micronaut-tests:micronaut-vertx-pg-client-native:test`
- `./gradlew :micronaut-tests:micronaut-vertx-pg-client-native:nativeTest`
- `./gradlew -q spotlessCheck`

Resolves #838
