### PR TITLE
Add regression for executor transaction isolation

### DIFF
--- a/jdbi/src/txTest/groovy/io/micronaut/configuration/jdbi/example/ApplicationSpec.groovy
+++ b/jdbi/src/txTest/groovy/io/micronaut/configuration/jdbi/example/ApplicationSpec.groovy
@@ -1,5 +1,6 @@
 package io.micronaut.configuration.jdbi.example
 
+import io.micronaut.configuration.jdbi.example.jdbitransaction.ExecutorTransactionIsolationService
 import io.micronaut.configuration.jdbi.example.jdbitransaction.ConcurrentTransactionsBug
 import io.micronaut.context.ApplicationContext
 import io.micronaut.context.DefaultApplicationContext
@@ -112,6 +113,29 @@ class ApplicationSpec extends Specification {
             bugService.noTransactionOrConnectionInDefaultMethod()
         then:
             noExceptionThrown()
+
+        cleanup:
+            dbSetup.drop()
+            applicationContext.close()
+    }
+
+    def "test executor work after commit uses a separate transaction"() {
+        given:
+            ApplicationContext applicationContext = new DefaultApplicationContext("test")
+            applicationContext.environment.addPropertySource(MapPropertySource.of(
+                    'test',
+                    ['datasources.default': [:]]
+            ))
+            applicationContext.start()
+
+        when:
+            def dbSetup = applicationContext.getBean(DatabaseSetup)
+            def service = applicationContext.getBean(ExecutorTransactionIsolationService)
+            dbSetup.initialize()
+            def count = service.executeAsyncTransactionAfterCommit()
+
+        then:
+            count == 2
 
         cleanup:
             dbSetup.drop()

--- a/jdbi/src/txTest/groovy/io/micronaut/configuration/jdbi/example/ApplicationSpec.groovy
+++ b/jdbi/src/txTest/groovy/io/micronaut/configuration/jdbi/example/ApplicationSpec.groovy
@@ -127,18 +127,22 @@ class ApplicationSpec extends Specification {
                     ['datasources.default': [:]]
             ))
             applicationContext.start()
+            DatabaseSetup dbSetup = null
 
         when:
-            def dbSetup = applicationContext.getBean(DatabaseSetup)
+            dbSetup = applicationContext.getBean(DatabaseSetup)
             def service = applicationContext.getBean(ExecutorTransactionIsolationService)
             dbSetup.initialize()
-            def count = service.executeAsyncTransactionAfterCommit()
+            def result = service.executeAsyncTransactionAfterCommit()
 
         then:
-            count == 2
+            result.count() == 2
+            result.innerNewTransaction()
 
         cleanup:
-            dbSetup.drop()
+            if (dbSetup != null) {
+                dbSetup.drop()
+            }
             applicationContext.close()
     }
 }

--- a/jdbi/src/txTest/groovy/io/micronaut/configuration/jdbi/example/jdbitransaction/ExecutorTransactionIsolationService.java
+++ b/jdbi/src/txTest/groovy/io/micronaut/configuration/jdbi/example/jdbitransaction/ExecutorTransactionIsolationService.java
@@ -1,0 +1,73 @@
+package io.micronaut.configuration.jdbi.example.jdbitransaction;
+
+import io.micronaut.scheduling.TaskExecutors;
+import io.micronaut.transaction.TransactionOperations;
+import io.micronaut.transaction.support.TransactionSynchronization;
+import jakarta.inject.Named;
+import jakarta.inject.Singleton;
+import org.jdbi.v3.core.Jdbi;
+
+import java.sql.Connection;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+@Singleton
+public class ExecutorTransactionIsolationService {
+
+    private final Jdbi jdbi;
+    private final TransactionOperations<Connection> transactionOperations;
+    private final ExecutorService executorService;
+
+    public ExecutorTransactionIsolationService(
+        Jdbi jdbi,
+        @Named("default") TransactionOperations<Connection> transactionOperations,
+        @Named(TaskExecutors.SCHEDULED) ExecutorService executorService
+    ) {
+        this.jdbi = jdbi;
+        this.transactionOperations = transactionOperations;
+        this.executorService = executorService;
+    }
+
+    public int executeAsyncTransactionAfterCommit() throws InterruptedException {
+        CountDownLatch completed = new CountDownLatch(1);
+        AtomicReference<Throwable> failure = new AtomicReference<>();
+
+        transactionOperations.executeWrite(status -> {
+            jdbi.useHandle(handle -> handle.execute("INSERT INTO books(id, name) VALUES(10, 'outer')"));
+            status.registerSynchronization(new TransactionSynchronization() {
+                @Override
+                public void afterCommit() {
+                    executorService.submit(() -> {
+                        try {
+                            transactionOperations.executeWrite(inner -> {
+                                jdbi.useHandle(handle -> handle.execute("INSERT INTO books(id, name) VALUES(11, 'inner')"));
+                                return null;
+                            });
+                        } catch (Throwable e) {
+                            failure.set(e);
+                        } finally {
+                            completed.countDown();
+                        }
+                    });
+                }
+            });
+            return null;
+        });
+
+        if (!completed.await(10, TimeUnit.SECONDS)) {
+            throw new IllegalStateException("Timed out waiting for asynchronous transactional work");
+        }
+        Throwable throwable = failure.get();
+        if (throwable instanceof RuntimeException runtimeException) {
+            throw runtimeException;
+        }
+        if (throwable != null) {
+            throw new RuntimeException(throwable);
+        }
+        return transactionOperations.executeRead(status ->
+            jdbi.withHandle(handle -> handle.createQuery("SELECT COUNT(*) FROM books").mapTo(Integer.class).one())
+        );
+    }
+}

--- a/jdbi/src/txTest/groovy/io/micronaut/configuration/jdbi/example/jdbitransaction/ExecutorTransactionIsolationService.java
+++ b/jdbi/src/txTest/groovy/io/micronaut/configuration/jdbi/example/jdbitransaction/ExecutorTransactionIsolationService.java
@@ -38,7 +38,7 @@ public class ExecutorTransactionIsolationService {
 
         transactionOperations.executeWrite(status -> {
             int outerBookId = nextBookId();
-            jdbi.useHandle(handle -> handle.execute("INSERT INTO books(id, name) VALUES(" + outerBookId + ", 'outer')"));
+            jdbi.useHandle(handle -> handle.execute("INSERT INTO books(id, name) VALUES(?, ?)", outerBookId, "outer"));
             status.registerSynchronization(new TransactionSynchronization() {
                 @Override
                 public void afterCommit() {
@@ -48,7 +48,7 @@ public class ExecutorTransactionIsolationService {
                                 transactionOperations.executeWrite(inner -> {
                                     innerNewTransaction.set(inner.isNewTransaction());
                                     int innerBookId = nextBookId();
-                                    jdbi.useHandle(handle -> handle.execute("INSERT INTO books(id, name) VALUES(" + innerBookId + ", 'inner')"));
+                                    jdbi.useHandle(handle -> handle.execute("INSERT INTO books(id, name) VALUES(?, ?)", innerBookId, "inner"));
                                     return null;
                                 });
                             } catch (Throwable e) {

--- a/jdbi/src/txTest/groovy/io/micronaut/configuration/jdbi/example/jdbitransaction/ExecutorTransactionIsolationService.java
+++ b/jdbi/src/txTest/groovy/io/micronaut/configuration/jdbi/example/jdbitransaction/ExecutorTransactionIsolationService.java
@@ -11,6 +11,7 @@ import java.sql.Connection;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
 @Singleton
@@ -30,27 +31,36 @@ public class ExecutorTransactionIsolationService {
         this.executorService = executorService;
     }
 
-    public int executeAsyncTransactionAfterCommit() throws InterruptedException {
+    public ExecutionResult executeAsyncTransactionAfterCommit() throws InterruptedException {
         CountDownLatch completed = new CountDownLatch(1);
         AtomicReference<Throwable> failure = new AtomicReference<>();
+        AtomicBoolean innerNewTransaction = new AtomicBoolean(false);
 
         transactionOperations.executeWrite(status -> {
-            jdbi.useHandle(handle -> handle.execute("INSERT INTO books(id, name) VALUES(10, 'outer')"));
+            int outerBookId = nextBookId();
+            jdbi.useHandle(handle -> handle.execute("INSERT INTO books(id, name) VALUES(" + outerBookId + ", 'outer')"));
             status.registerSynchronization(new TransactionSynchronization() {
                 @Override
                 public void afterCommit() {
-                    executorService.submit(() -> {
-                        try {
-                            transactionOperations.executeWrite(inner -> {
-                                jdbi.useHandle(handle -> handle.execute("INSERT INTO books(id, name) VALUES(11, 'inner')"));
-                                return null;
-                            });
-                        } catch (Throwable e) {
-                            failure.set(e);
-                        } finally {
-                            completed.countDown();
-                        }
-                    });
+                    try {
+                        executorService.submit(() -> {
+                            try {
+                                transactionOperations.executeWrite(inner -> {
+                                    innerNewTransaction.set(inner.isNewTransaction());
+                                    int innerBookId = nextBookId();
+                                    jdbi.useHandle(handle -> handle.execute("INSERT INTO books(id, name) VALUES(" + innerBookId + ", 'inner')"));
+                                    return null;
+                                });
+                            } catch (Throwable e) {
+                                failure.set(e);
+                            } finally {
+                                completed.countDown();
+                            }
+                        });
+                    } catch (Throwable e) {
+                        failure.set(e);
+                        completed.countDown();
+                    }
                 }
             });
             return null;
@@ -66,8 +76,20 @@ public class ExecutorTransactionIsolationService {
         if (throwable != null) {
             throw new RuntimeException(throwable);
         }
-        return transactionOperations.executeRead(status ->
+        int count = transactionOperations.executeRead(status ->
             jdbi.withHandle(handle -> handle.createQuery("SELECT COUNT(*) FROM books").mapTo(Integer.class).one())
         );
+        return new ExecutionResult(count, innerNewTransaction.get());
+    }
+
+    private int nextBookId() {
+        return jdbi.withHandle(handle ->
+            handle.createQuery("SELECT COALESCE(MAX(id), 0) + 1 FROM books")
+                .mapTo(Integer.class)
+                .one()
+        );
+    }
+
+    public record ExecutionResult(int count, boolean innerNewTransaction) {
     }
 }


### PR DESCRIPTION
## Summary
Adds JDBI transaction coverage for executor-submitted work started from `afterCommit`, asserting the follow-up write runs in an independent transaction.

## Verification
- `./gradlew :micronaut-jdbi:txTest --console=plain`

Resolves #1508