### PR TITLE
Expose RxJava3 PgPool bean

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -89,6 +89,7 @@ managed-vertx-pg-client = { module = "io.vertx:vertx-pg-client", version.ref = "
 managed-vertx-mssql-client = { module = "io.vertx:vertx-mssql-client", version.ref = "managed-vertx" }
 managed-vertx-oracle-client = { module = "io.vertx:vertx-oracle-client", version.ref = "managed-vertx" }
 managed-vertx-rx-java2 = { module = "io.vertx:vertx-rx-java2", version.ref = "managed-vertx" }
+managed-vertx-rx-java3 = { module = "io.vertx:vertx-rx-java3", version.ref = "managed-vertx" }
 
 boms-jooq = { module = "org.jooq:jooq-bom", version.ref = "managed-jooq" }
 managed-jooq = { module = "org.jooq:jooq", version.ref = "managed-jooq" }

--- a/src/main/docs/guide/vertxpgclient.adoc
+++ b/src/main/docs/guide/vertxpgclient.adoc
@@ -30,13 +30,13 @@ vertx:
 
 TIP: You can also connect to PostgreSQL using `uri` instead of the other properties.
 
-Once you have the above configuration in place then you can inject the `io.vertx.reactivex.pgclient.PgPool` bean. The following is the simplest way to connect:
+Once you have the above configuration in place then you can inject the core `io.vertx.sqlclient.Pool` bean. If `io.vertx:vertx-rx-java3` is on the classpath, Micronaut also exposes the RxJava3 `io.vertx.rxjava3.sqlclient.Pool` wrapper bean. The following is the simplest way to connect:
 
 [source,groovy]
 ----
 include::vertx-pg-client/src/test/groovy/io/micronaut/configuration/vertx/pg/client/PgClientSpec.groovy[tags=query,indent=0]
 ----
 
-<1> `client` is an instance of the `io.vertx.reactivex.pgclient.PgPool` bean.
+<1> `client` is an instance of the `io.vertx.sqlclient.Pool` bean.
 
 For more information on running queries on Postgres using the reactive client please read the "Running queries" section in the documentation of https://vertx.io/docs/vertx-pg-client/java/[vertx-pg-client].

--- a/vertx-pg-client/build.gradle
+++ b/vertx-pg-client/build.gradle
@@ -9,10 +9,12 @@ dependencies {
     implementation(libs.managed.vertx.codegen)
     implementation(mnReactor.micronaut.reactor)
 
+    compileOnly(libs.managed.vertx.rx.java3)
+
     compileOnly(mn.micronaut.management)
     runtimeOnly libs.managed.ongres.scram.client
 
     testImplementation(mn.micronaut.management)
+    testImplementation(libs.managed.vertx.rx.java3)
     testImplementation(mnTestResources.testcontainers.postgres)
 }
-

--- a/vertx-pg-client/src/main/java/io/micronaut/configuration/vertx/pg/client/PgClientRxJava3Factory.java
+++ b/vertx-pg-client/src/main/java/io/micronaut/configuration/vertx/pg/client/PgClientRxJava3Factory.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.configuration.vertx.pg.client;
+
+import io.micronaut.context.annotation.Factory;
+import io.micronaut.context.annotation.Requires;
+import io.vertx.sqlclient.Pool;
+import jakarta.inject.Singleton;
+
+/**
+ * Exposes the RxJava3 SQL client wrapper when the RxJava3 Vert.x integration is present.
+ */
+@Factory
+@Requires(classes = io.vertx.rxjava3.sqlclient.Pool.class)
+final class PgClientRxJava3Factory {
+
+    /**
+     * @param client The Vert.x SQL client pool
+     * @return The RxJava3 SQL client pool wrapper
+     */
+    @Singleton
+    @Requires(missingBeans = io.vertx.rxjava3.sqlclient.Pool.class)
+    io.vertx.rxjava3.sqlclient.Pool rxClient(Pool client) {
+        return new io.vertx.rxjava3.sqlclient.Pool(client);
+    }
+}

--- a/vertx-pg-client/src/test/groovy/io/micronaut/configuration/vertx/pg/client/PgClientConfigurationSpec.groovy
+++ b/vertx-pg-client/src/test/groovy/io/micronaut/configuration/vertx/pg/client/PgClientConfigurationSpec.groovy
@@ -17,6 +17,7 @@ package io.micronaut.configuration.vertx.pg.client
 
 
 import io.micronaut.context.ApplicationContext
+import io.vertx.sqlclient.Pool
 import spock.lang.Specification
 
 
@@ -48,6 +49,27 @@ class PgClientConfigurationSpec extends Specification {
         applicationContext?.stop()
     }
 
+    void "test rxjava3 sql client pool bean is exposed when rxjava3 is on the classpath"() {
+        given:
+        ApplicationContext applicationContext = ApplicationContext.run(
+                'vertx.pg.client.port': '5432',
+                'vertx.pg.client.host': 'the-host',
+                'vertx.pg.client.database': 'the-db',
+                'vertx.pg.client.user': 'user',
+                'vertx.pg.client.password': 'secret',
+                'vertx.pg.client.maxSize': '5'
+        )
+
+        when:
+        Pool pool = applicationContext.getBean(Pool)
+
+        then:
+        applicationContext.containsBean(io.vertx.rxjava3.sqlclient.Pool)
+        applicationContext.getBean(io.vertx.rxjava3.sqlclient.Pool).delegate.is(pool)
+
+        cleanup:
+        applicationContext?.stop()
+    }
 
 
 }


### PR DESCRIPTION
## Summary
- expose an `io.vertx.rxjava3.sqlclient.Pool` bean when RxJava3 support is on the classpath
- add regression coverage proving the RxJava3 wrapper delegates to the core pool bean
- update the Vert.x Postgres guide to document the core pool bean and optional RxJava3 wrapper

## Verification
- `./gradlew :micronaut-vertx-pg-client:test --tests io.micronaut.configuration.vertx.pg.client.PgClientConfigurationSpec`
- `./gradlew :micronaut-vertx-pg-client:test` (fails in this environment because Docker is unavailable for the existing Testcontainers-based specs)

Resolves #1333