### PR TITLE
Clarify jOOQ R2DBC support

### DIFF
--- a/jooq/src/test/groovy/io/micronaut/configuration/jooq/R2dbcDslContextSpec.groovy
+++ b/jooq/src/test/groovy/io/micronaut/configuration/jooq/R2dbcDslContextSpec.groovy
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.configuration.jooq
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.DefaultApplicationContext
+import io.micronaut.context.env.MapPropertySource
+import io.micronaut.inject.qualifiers.Qualifiers
+import io.r2dbc.spi.ConnectionFactory
+import io.r2dbc.spi.ConnectionFactoryMetadata
+import org.jooq.Configuration
+import org.jooq.DSLContext
+import org.jooq.SQLDialect
+import spock.lang.Specification
+
+import javax.sql.DataSource
+
+class R2dbcDslContextSpec extends Specification {
+
+    void "test r2dbc configuration creates dsl context without jdbc datasource"() {
+        given:
+        ApplicationContext applicationContext = new DefaultApplicationContext("test")
+        applicationContext.registerSingleton(ConnectionFactory, Stub(ConnectionFactory) {
+            getMetadata() >> Stub(ConnectionFactoryMetadata) {
+                getName() >> "stub"
+            }
+        }, Qualifiers.byName("default"))
+        applicationContext.start()
+
+        expect:
+        !applicationContext.containsBean(DataSource)
+        applicationContext.containsBean(ConnectionFactory)
+        applicationContext.containsBean(Configuration)
+        applicationContext.containsBean(DSLContext)
+        applicationContext.getBean(DSLContext).configuration().dialect() == SQLDialect.DEFAULT
+
+        cleanup:
+        applicationContext.close()
+    }
+
+    void "test r2dbc sql dialect override"() {
+        given:
+        ApplicationContext applicationContext = new DefaultApplicationContext("test")
+        applicationContext.environment.addPropertySource(MapPropertySource.of(
+            "test",
+            ["jooq.r2dbc-datasources.default.sql-dialect": "POSTGRES"]
+        ))
+        applicationContext.registerSingleton(ConnectionFactory, Stub(ConnectionFactory) {
+            getMetadata() >> Stub(ConnectionFactoryMetadata) {
+                getName() >> "stub"
+            }
+        }, Qualifiers.byName("default"))
+        applicationContext.start()
+
+        when:
+        Configuration configuration = applicationContext.getBean(DSLContext).configuration()
+
+        then:
+        configuration.dialect() == SQLDialect.POSTGRES
+
+        cleanup:
+        applicationContext.close()
+    }
+}

--- a/src/main/docs/guide/jooq.adoc
+++ b/src/main/docs/guide/jooq.adoc
@@ -4,8 +4,8 @@ To configure jOOQ library you should first add `jooq` module to your classpath:
 
 dependency:micronaut-jooq[groupId="io.micronaut.sql"]
 
-You should then <<jdbc, configure one or many DataSources>>.
-For each registered `DataSource`, Micronaut will configure the following jOOQ beans using api:configuration.jooq.JooqConfigurationFactory[]:
+You should then either <<jdbc, configure one or many DataSources>> or <<jooq-r2dbc, configure one or many R2DBC ConnectionFactory instances>>.
+For each registered `DataSource` or `ConnectionFactory`, Micronaut will configure the following jOOQ beans using api:configuration.jooq.JooqConfigurationFactory[] or api:configuration.jooq.R2dbcJooqConfigurationFactory[]:
 
 * link:{jooqapi}/org/jooq/Configuration.html[Configuration] - jOOQ `Configuration`
 * link:{jooqapi}/org/jooq/DSLContext.html[DSLContext] - jOOQ `DSLContext`
@@ -14,4 +14,3 @@ If Spring transaction management is in use, it will additionally create the foll
 
 * api:configuration.jooq.JooqExceptionTranslatorProvider[] for each `DataSource`
 * api:configuration.jooq.SpringTransactionProvider[] for each Spring `PlatformTransactionManager`
-

--- a/src/main/docs/guide/jooq/jooq-r2dbc.adoc
+++ b/src/main/docs/guide/jooq/jooq-r2dbc.adoc
@@ -1,0 +1,21 @@
+Micronaut also configures jOOQ for each named `ConnectionFactory` when R2DBC is on the classpath.
+Use the same logical data source name for both `r2dbc.datasources.*` and `jooq.r2dbc-datasources.*`.
+
+[configuration]
+----
+r2dbc:
+  datasources:
+    default:
+      db-type: postgres
+      options:
+        driver: pool
+        protocol: postgresql
+jooq:
+  r2dbc-datasources:
+    default:
+      sql-dialect: postgres
+----
+
+The `sql-dialect` setting is optional. When it is not configured, jOOQ falls back to `DEFAULT`.
+
+include::{includedir}configurationProperties/io.micronaut.configuration.jooq.R2dbcJooqConfigurationProperties.adoc[]

--- a/src/main/docs/guide/toc.yml
+++ b/src/main/docs/guide/toc.yml
@@ -23,6 +23,7 @@ jasync:
   jasync-healthchecks: Database Health Checks
 jooq:
   title: Configuring jOOQ
+  jooq-r2dbc: Configuring R2DBC connection factories
   jooq-dialect: Configuring SQL dialect
   jooq-provider-beans: Configuring additional provider beans
   jooq-jsonb: Using JsonMapper to convert JSON(B) types

--- a/tests/jooq-tests/jooq-r2dbc-postgres/src/main/java/example/jooq/reactive/PetRepository.java
+++ b/tests/jooq-tests/jooq-r2dbc-postgres/src/main/java/example/jooq/reactive/PetRepository.java
@@ -55,7 +55,7 @@ public class PetRepository extends AbstractRepository implements IPetRepository 
     @Transactional(Transactional.TxType.MANDATORY)
     @Override
     public Mono<Void> save(IPet pet) {
-        return withDSLContextMono(dslContext -> ctx.insertInto(PET_TABLE)
+        return withDSLContextMono(dslContext -> dslContext.insertInto(PET_TABLE)
             .columns(PET_NAME, PET_TYPE, PET_OWNER)
             .values(pet.getName(), pet.getType() == null ? null : pet.getType().name(), pet.getOwner().getId())
             .returning(PET_ID)).map(q -> q.get(PET_ID))


### PR DESCRIPTION
## Summary
- add focused jOOQ R2DBC bean wiring coverage in the  module
- document how to configure  alongside named R2DBC connection factories
- fix the reactive jOOQ sample to use the transaction-scoped 

Resolves #1336