### PR TITLE
docs: document Micronaut JDBC transaction management

### DIFF
--- a/src/main/docs/guide/hibernate/hibernate-inject-session.adoc
+++ b/src/main/docs/guide/hibernate/hibernate-inject-session.adoc
@@ -16,4 +16,4 @@ EntityManager entityManager;
 EntityManager otherManager;
 ----
 
-Micronaut will inject a compile time scoped proxy that retrieves the `EntityManager` associated with the current transaction when using https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/transaction/annotation/Transactional.html[@Transactional] (see "Using Spring Transaction Management" below).
+Micronaut will inject a compile time scoped proxy that retrieves the `EntityManager` associated with the current transaction when using `@Transactional` (see <<jdbc-transactions, Transaction Management>>).

--- a/src/main/docs/guide/hibernate/hibernate-inject-session.adoc
+++ b/src/main/docs/guide/hibernate/hibernate-inject-session.adoc
@@ -16,4 +16,6 @@ EntityManager entityManager;
 EntityManager otherManager;
 ----
 
-Micronaut will inject a compile time scoped proxy that retrieves the `EntityManager` associated with the current transaction when using `@Transactional` (see <<jdbc-transactions, Transaction Management>>).
+Micronaut will inject a compile time scoped proxy that retrieves the `EntityManager` associated with the current transaction when using `jakarta.transaction.Transactional` (or `io.micronaut.transaction.annotation.Transactional`).
+
+For Hibernate/JPA transaction management, use `micronaut-data-tx-hibernate` as described in <<hibernate, Setting up a Hibernate/JPA EntityManager>>.

--- a/src/main/docs/guide/hibernate/hibernate-lazy-initialization.adoc
+++ b/src/main/docs/guide/hibernate/hibernate-lazy-initialization.adoc
@@ -1,6 +1,6 @@
 Micronaut is built on Netty which is based on a non-blocking, event loop model. JDBC and Hibernate are blocking APIs and hence when they are used in a Micronaut application the work is shifted to a blocking I/O thread pool.
 
-When using `@Transactional` the Hibernate `Session` will only be open for the duration of this method execution and then will automatically be closed. This ensures that the blocking operation is kept as short as possible.
+When using `jakarta.transaction.Transactional` (or `io.micronaut.transaction.annotation.Transactional`) the Hibernate `Session` will only be open for the duration of this method execution and then will automatically be closed. This ensures that the blocking operation is kept as short as possible.
 
 There is no notion of OpenSessionInView (OSIV) in Micronaut and never will be, since it is https://vladmihalcea.com/the-open-session-in-view-anti-pattern/[sub-optimal and not recommended]. You should optimize the queries that you write to return all the necessary data Micronaut will need to encode your objects into JSON either by using the appropriate join queries or using a https://vladmihalcea.com/the-best-way-to-map-a-projection-query-to-a-dto-with-jpa-and-hibernate/[data transfer object (DTO)].
 

--- a/src/main/docs/guide/hibernate/hibernate-lazy-initialization.adoc
+++ b/src/main/docs/guide/hibernate/hibernate-lazy-initialization.adoc
@@ -1,6 +1,6 @@
 Micronaut is built on Netty which is based on a non-blocking, event loop model. JDBC and Hibernate are blocking APIs and hence when they are used in a Micronaut application the work is shifted to a blocking I/O thread pool.
 
-When using https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/transaction/annotation/Transactional.html[@Transactional] the Hibernate `Session` will only be open for the duration of this method execution and then will automatically be closed. This ensures that the blocking operation is kept as short as possible.
+When using `@Transactional` the Hibernate `Session` will only be open for the duration of this method execution and then will automatically be closed. This ensures that the blocking operation is kept as short as possible.
 
 There is no notion of OpenSessionInView (OSIV) in Micronaut and never will be, since it is https://vladmihalcea.com/the-open-session-in-view-anti-pattern/[sub-optimal and not recommended]. You should optimize the queries that you write to return all the necessary data Micronaut will need to encode your objects into JSON either by using the appropriate join queries or using a https://vladmihalcea.com/the-best-way-to-map-a-projection-query-to-a-dto-with-jpa-and-hibernate/[data transfer object (DTO)].
 

--- a/src/main/docs/guide/jdbc.adoc
+++ b/src/main/docs/guide/jdbc.adoc
@@ -30,3 +30,5 @@ To use SQLite, add the Xerial JDBC driver:
 dependency:sqlite-jdbc[groupId="org.xerial", scope="runtime"]
 
 When the SQLite driver is present, Micronaut can automatically configure an embedded shared in-memory datasource for `db-type: sqlite` if you do not provide an explicit JDBC URL.
+
+To configure Micronaut-managed JDBC transactions without Spring, see <<jdbc-transactions, Transaction Management>>.

--- a/src/main/docs/guide/jdbc/jdbc-transactions.adoc
+++ b/src/main/docs/guide/jdbc/jdbc-transactions.adoc
@@ -1,0 +1,26 @@
+Spring is not required for transaction management with JDBC. To enable Micronaut-managed JDBC transactions, add the following dependency:
+
+dependency:micronaut-data-tx-jdbc[groupId="io.micronaut.data"]
+
+This module configures the JDBC transaction manager and includes the Jakarta Transactions API.
+
+You can annotate transactional methods with either `jakarta.transaction.Transactional` or `io.micronaut.transaction.annotation.Transactional`. For read-only operations, you can also use `io.micronaut.transaction.annotation.ReadOnly`.
+
+[source,java]
+.Using `@Transactional` with JDBC
+----
+import jakarta.transaction.Transactional;
+
+@Transactional
+void saveBook(Book book) {
+    // use the injected DataSource here
+}
+----
+
+If you need Micronaut-specific options such as `readOnly`, `transactionManager`, or `propagation`, use `io.micronaut.transaction.annotation.Transactional`.
+
+This transaction support works with plain JDBC access and with integrations built on top of a JDBC `DataSource`, such as Jdbi and JDBC-backed jOOQ.
+
+When using direct JDBC access, obtain connections from the injected `DataSource` inside a transactional method, or from a method that is invoked within a transaction boundary, so Micronaut can associate the connection with the active transaction.
+
+Spring transaction management remains optional and should only be added if your application specifically needs Spring transaction APIs.

--- a/src/main/docs/guide/jdbc/jdbc-transactions.adoc
+++ b/src/main/docs/guide/jdbc/jdbc-transactions.adoc
@@ -1,8 +1,12 @@
-Spring is not required for transaction management with JDBC. To enable Micronaut-managed JDBC transactions, add the following dependency:
+Spring is not required for transaction management with plain JDBC access or other integrations built on top of a JDBC `DataSource`. To enable Micronaut-managed transactions for those JDBC-backed integrations, add the following dependency:
 
 dependency:micronaut-data-tx-jdbc[groupId="io.micronaut.data"]
 
 This module configures the JDBC transaction manager and includes the Jakarta Transactions API.
+
+If you are using Hibernate/JPA, do not add `micronaut-data-tx-jdbc` for transaction management. Use the Hibernate transaction module instead:
+
+dependency:micronaut-data-tx-hibernate[groupId="io.micronaut.data"]
 
 You can annotate transactional methods with either `jakarta.transaction.Transactional` or `io.micronaut.transaction.annotation.Transactional`. For read-only operations, you can also use `io.micronaut.transaction.annotation.ReadOnly`.
 

--- a/src/main/docs/guide/jdbi.adoc
+++ b/src/main/docs/guide/jdbi.adoc
@@ -9,6 +9,8 @@ For each registered `DataSource`, Micronaut will configure the following Jdbi be
 
 * link:{jdbiapi}/org/jdbi/v3/core/Jdbi.html[Jdbi] - the `Jdbi` instance
 
+For Jdbi applications that use Micronaut transaction management, configure <<jdbc-transactions, Transaction Management>>.
+
 If Spring transaction management is in use, it will additionally create the following beans :
 
 * api:configuration.jdbi.spring.SpringTransactionHandler[SpringTransactionHandler] for each Spring `PlatformTransactionManager`

--- a/src/main/docs/guide/jooq.adoc
+++ b/src/main/docs/guide/jooq.adoc
@@ -10,6 +10,8 @@ For each registered `DataSource` or `ConnectionFactory`, Micronaut will configur
 * link:{jooqapi}/org/jooq/Configuration.html[Configuration] - jOOQ `Configuration`
 * link:{jooqapi}/org/jooq/DSLContext.html[DSLContext] - jOOQ `DSLContext`
 
+For JDBC-backed jOOQ applications that use Micronaut transaction management, configure <<jdbc-transactions, Transaction Management>>.
+
 If Spring transaction management is in use, it will additionally create the following beans :
 
 * api:configuration.jooq.JooqExceptionTranslatorProvider[] for each `DataSource`

--- a/src/main/docs/guide/toc.yml
+++ b/src/main/docs/guide/toc.yml
@@ -6,6 +6,7 @@ jdbc:
   jdbc-disable: Disable Micronaut JDBC Data Sources
   jdbc-connection-pools: Configuring JDBC Connection Pools
   jdbc-multiple-datasources: Configuring Multiple Data Sources
+  jdbc-transactions: Transaction Management
   jdbc-healthchecks: JDBC Health Checks
   jdbc-runtime-password-update: Data Source Runtime Password Change
 hibernate:


### PR DESCRIPTION
## Summary
- add a JDBC transaction management guide section for Micronaut-managed transactions
- link JDBC, Hibernate, Jdbi, and JDBC-backed jOOQ docs to the shared transaction guidance
- remove stale Spring-only wording where the docs now describe generic `@Transactional` usage

## Testing
- `./gradlew publishGuide`
- `./gradlew docs`

Resolves #558
