### PR TITLE
docs(hibernate): document GraalVM native image requirements

### DIFF
--- a/src/main/docs/guide/hibernate/hibernate-graalvm.adoc
+++ b/src/main/docs/guide/hibernate/hibernate-graalvm.adoc
@@ -1,0 +1,93 @@
+To run Hibernate on GraalVM native image you need to configure more than entity scanning alone. The Hibernate runtime normally depends on reflective model inspection and runtime proxy generation, both of which need extra setup in a native image.
+
+For Hibernate applications on GraalVM, make sure all of the following are true:
+
+* Entity discovery uses Micronaut entity scanning, not full classpath scanning
+* Lazy associations use compile-time Hibernate proxies instead of runtime-generated proxies
+* Types that Hibernate still needs to inspect reflectively are registered for reflection
+
+== Entity Scanning
+
+Micronaut's default entity scanning works in native image because it relies on Micronaut metadata instead of scanning the full classpath.
+
+Avoid enabling `jpa.*.entity-scan.classpath=true` for GraalVM native image. Full classpath scanning does not work in a native executable.
+
+If your entities are not compiled by Micronaut, generate introspection metadata for them instead:
+
+[source,java]
+----
+@Introspected(packages = "example.domain")
+----
+
+See the entity scan configuration section for the full set of options.
+
+== Lazy Associations
+
+If your model uses lazy associations, Hibernate must create proxies for the associated entity types. Runtime proxy generation is not a good fit for GraalVM native image, so use Micronaut's compile-time Hibernate proxies instead.
+
+[configuration]
+.Enable Compile-Time Hibernate Proxies
+----
+jpa:
+  default:
+    compile-time-hibernate-proxies: true
+----
+
+Each entity type that Hibernate may proxy must be annotated with `@GenerateProxy`:
+
+[source,java]
+----
+@Entity
+@GenerateProxy
+public class Owner {
+    // ...
+}
+----
+
+Then any lazy association pointing to that entity can be resolved without falling back to Hibernate's runtime proxy generation:
+
+[source,java]
+----
+@Entity
+public class Pet {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Owner owner;
+}
+----
+
+[NOTE]
+Compile-time Hibernate proxies are enabled by default for the GraalVM environment. The `@GenerateProxy` annotation is still required on each entity type that Hibernate may proxy.
+
+== Reflection Requirements
+
+Even with Micronaut entity scanning and compile-time proxies enabled, Hibernate may still need reflective access to some model types at runtime.
+
+In particular, embeddable identifier types used with `@EmbeddedId` should be annotated with `@ReflectiveAccess`:
+
+[source,java]
+----
+@Embeddable
+@ReflectiveAccess
+public class OrderId implements Serializable {
+    // ...
+}
+----
+
+And then used from the entity as usual:
+
+[source,java]
+----
+@Entity
+public class Order {
+
+    @EmbeddedId
+    private OrderId id;
+}
+----
+
+If a native-image build works on the JVM but fails only once Hibernate starts inspecting metadata or creating proxies in the native executable, check these three areas first:
+
+* Entity scanning is not using classpath scanning
+* Lazy association targets are annotated with `@GenerateProxy`
+* Embeddable identifier types and other reflectively accessed model types are annotated with `@ReflectiveAccess`

--- a/src/main/docs/guide/hibernate/hibernate-graalvm.adoc
+++ b/src/main/docs/guide/hibernate/hibernate-graalvm.adoc
@@ -57,7 +57,7 @@ public class Pet {
 ----
 
 [NOTE]
-Compile-time Hibernate proxies are enabled by default for the GraalVM environment. The `@GenerateProxy` annotation is still required on each entity type that Hibernate may proxy.
+For GraalVM native image, enable compile-time Hibernate proxies as shown above. The `@GenerateProxy` annotation is still required on each entity type that Hibernate may proxy.
 
 == Reflection Requirements
 

--- a/src/main/docs/guide/hibernate/hibernate-graalvm.adoc
+++ b/src/main/docs/guide/hibernate/hibernate-graalvm.adoc
@@ -19,7 +19,7 @@ If your entities are not compiled by Micronaut, generate introspection metadata 
 @Introspected(packages = "example.domain")
 ----
 
-See the entity scan configuration section for the full set of options.
+See the <<hibernate-entity-scan,entity scan configuration section>> for the full set of options.
 
 == Lazy Associations
 
@@ -86,7 +86,7 @@ public class Order {
 }
 ----
 
-If a native-image build works on the JVM but fails only once Hibernate starts inspecting metadata or creating proxies in the native executable, check these three areas first:
+If the application works on the JVM but fails only once Hibernate starts inspecting metadata or creating proxies in the native executable, check these three areas first:
 
 * Entity scanning is not using classpath scanning
 * Lazy association targets are annotated with `@GenerateProxy`

--- a/src/main/docs/guide/hibernate/hibernate-proxies.adoc
+++ b/src/main/docs/guide/hibernate/hibernate-proxies.adoc
@@ -6,14 +6,14 @@ This has a few disadvantages:
 * Environments like GraalVM don't support it
 
 If you wish to use lazy entity associations and avoid runtime proxies you can enable compile-time proxies:
-[source,yaml]
+[configuration]
 ----
 jpa:
   default:
     compile-time-hibernate-proxies: true
 ----
 
-Compile-time proxies require for an entity which needs to have a proxy to be annotated with `@GenerateProxy`:
+Compile-time proxies require every entity type that Hibernate may proxy to be annotated with `@GenerateProxy`:
 
 For example:
 
@@ -29,7 +29,7 @@ public class Pet {
 }
 ----
 
-The entity `Owner` needs to be annotated with `@GenerateProxy` to have a proxy generated and the compile-time.
+The entity `Owner` needs to be annotated with `@GenerateProxy` to have a proxy generated at compile time.
 
 [source,java]
 ----
@@ -42,3 +42,5 @@ public class Owner {
 
 [NOTE]
 Compile-time proxies are enabled by default for GraalVM environment.
+
+For the full set of Hibernate native image requirements, including entity scanning and reflective access for embeddable identifier types, see the GraalVM native image section in this chapter.

--- a/src/main/docs/guide/hibernate/hibernate-proxies.adoc
+++ b/src/main/docs/guide/hibernate/hibernate-proxies.adoc
@@ -41,6 +41,6 @@ public class Owner {
 ----
 
 [NOTE]
-Compile-time proxies are enabled by default for GraalVM environment.
+For GraalVM native image, enable compile-time proxies with the configuration shown above.
 
 For the full set of Hibernate native image requirements, including entity scanning and reflective access for embeddable identifier types, see the <<hibernate-graalvm,GraalVM native image section>> in this chapter.

--- a/src/main/docs/guide/hibernate/hibernate-proxies.adoc
+++ b/src/main/docs/guide/hibernate/hibernate-proxies.adoc
@@ -43,4 +43,4 @@ public class Owner {
 [NOTE]
 Compile-time proxies are enabled by default for GraalVM environment.
 
-For the full set of Hibernate native image requirements, including entity scanning and reflective access for embeddable identifier types, see the GraalVM native image section in this chapter.
+For the full set of Hibernate native image requirements, including entity scanning and reflective access for embeddable identifier types, see the <<hibernate-graalvm,GraalVM native image section>> in this chapter.

--- a/src/main/docs/guide/toc.yml
+++ b/src/main/docs/guide/toc.yml
@@ -14,6 +14,7 @@ hibernate:
   hibernate-inject-session: Injecting an EntityManager or Hibernate Session
   hibernate-customizing: Customizing Hibernate/JPA Configuration
   hibernate-entity-scan: Entity Scan Configuration
+  hibernate-graalvm: GraalVM native image
   hibernate-reactive: Configuring Hibernate Reactive
   hibernate-proxies: Using compile-time Hibernate proxies
   hibernate-lazy-initialization: Understanding LazyInitializationException


### PR DESCRIPTION
## Summary
- add a dedicated Hibernate GraalVM native-image guide page
- document the three requirements the current codebase needs in native image: Micronaut entity scanning, compile-time Hibernate proxies for lazy associations, and reflective access for embeddable id types
- add a pointer from the compile-time proxy page to the full native-image requirements

## Verification
- `./gradlew publishGuide`
- `./gradlew docs`

Partially addresses #716
