### PR TITLE
Fix jOOQ graalvm compilation

### DIFF
--- a/jooq/src/main/resources/META-INF/native-image/io.micronaut.sql/jooq-graal/native-image.properties
+++ b/jooq/src/main/resources/META-INF/native-image/io.micronaut.sql/jooq-graal/native-image.properties
@@ -17,4 +17,5 @@
 Args = -H:ClassInitialization=org.jooq.SQLDialect$ThirdParty:build_time \
        --initialize-at-run-time=io.micronaut.configuration.jooq.spring.SpringTransactionProvider,io.micronaut.configuration.jooq.spring.JooqExceptionTranslator \
        --initialize-at-build-time=org.jooq.impl.DefaultDataType,org.jooq.impl.SQLDataType,org.jooq.impl.BuiltInDataType,org.jooq.impl.ArrayDataType,org.jooq.impl.AbstractDataType,org.jooq.SQLDialect \
-       --initialize-at-build-time=org.jooq,org.jooq.impl,org.jooq.conf
+       --initialize-at-build-time=org.jooq,org.jooq.impl,org.jooq.conf \
+       --initialize-at-build-time=tools.jackson.databind,tools.jackson.core,com.fasterxml.jackson.annotation


### PR DESCRIPTION
Replaces #2067. Reopened as a new PR since native-image.properties was simplified in #2068, and rebasing onto latest 7.2.x avoids merge issues, as suggested by @radovanradic.

Adds `tools.jackson,com.fasterxml.jackson` to the `--initialize-at-build-time` list in the jOOQ native-image config. Without this, I hit a NullPointerException in org.jooq.impl.DefaultDataType during SQLDataType.<clinit> at GraalVM native image runtime.